### PR TITLE
chore: release 2025.01.26

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,17 @@
+### 2025.01.26
+
+#### @hertzg/wg-conf 0.1.2 (minor)
+
+- feat(wg-conf): wg-quick config parser and serializer
+
+#### @hertzg/wg-ini 0.1.3 (patch)
+
+- BREAKING(wg-ini)!: rewrite to use streams
+
+#### @hertzg/wg-keys 0.1.3 (patch)
+
+- chore(*): use import_map.json when bumping
+
 ### 2025.01.25
 
 #### @hertzg/wg-ini 0.1.2 (minor)

--- a/import_map.json
+++ b/import_map.json
@@ -4,8 +4,8 @@
     "@std/streams": "jsr:@std/streams@^1.0.8",
     "@noble/curves": "jsr:@noble/curves@^1.8.1",
     "@noble/curves/ed25519": "jsr:@noble/curves@^1.8.1/ed25519",
-    "@hertzg/wg-keys": "jsr:@hertzg/wg-keys@^0.1.2",
-    "@hertzg/wg-ini": "jsr:@hertzg/wg-ini@^0.1.2",
+    "@hertzg/wg-keys": "jsr:@hertzg/wg-keys@^0.1.3",
+    "@hertzg/wg-ini": "jsr:@hertzg/wg-ini@^0.1.3",
     "@hertzg/wg-conf": "jsr:@hertzg/wg-conf@^0.1.2"
   }
 }

--- a/ini/deno.json
+++ b/ini/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/wg-ini",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "exports": {
     ".": "./mod.ts",
     "./lines": "./lines.ts",

--- a/keys/deno.json
+++ b/keys/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/wg-keys",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "exports": "./mod.ts",
   "include": [
     "mod.ts"


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|wg-conf|0.0.0|0.1.2|minor|
|wg-ini|0.1.2|0.1.3|patch|
|@hertzg/wg-keys|0.1.2|0.1.3|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly









---

To make edits to this PR:

```sh
git fetch upstream release-2025-01-26-23-16-06 && git checkout -b release-2025-01-26-23-16-06 upstream/release-2025-01-26-23-16-06
```
