### PR TITLE
chore: release 2025.01.26

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,22 @@
+### 2025.01.26
+
+#### @hertzg/wg-conf 0.1.2 (minor)
+
+- feat(wg-conf,wg-ini,wg-keys): rename folders to match the name
+- feat(wg-conf): wg-quick config parser and serializer
+- fix(wg-conf,wg-ini): fix wrong imports
+
+#### @hertzg/wg-ini 0.1.2 (minor)
+
+- BREAKING(wg-ini)!: rewrite to use streams
+- feat(wg-conf,wg-ini,wg-keys): rename folders to match the name
+- fix(wg-conf,wg-ini): fix wrong imports
+- chore(wg-ini): ser version manually to 0.1.0
+
+#### @hertzg/wg-keys 0.1.2 (patch)
+
+- feat(wg-conf,wg-ini,wg-keys): rename folders to match the name
+
 ### 2025.01.25
 
 #### @hertzg/wg-ini 0.1.2 (minor)


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|wg-conf|0.0.0|0.1.2|minor|
|wg-ini|0.0.1|0.1.2|minor|
|wg-keys|0.1.0|0.1.2|patch|

Please ensure:
- [x] Versions in deno.json files are updated correctly
- [x] Releases.md is updated correctly

The following commits are not recognized. Please handle them manually if necessary:

- [Merge pull request #4 from hertzg/release-2025-01-25-20-33-56](/hertzg/jsr-monorepo/commit/5a83764a9b630abe687f9ba4eff369c1d43a7011)
- [Merge pull request #3 from hertzg/release-2025-01-25-20-23-49](/hertzg/jsr-monorepo/commit/d86d2bbb4eebd3a38e7bfe5c4331f89be0ae9dff)
- [Merge remote-tracking branch 'upstream/main' into release-2025-01-25-20-23-49](/hertzg/jsr-monorepo/commit/5cc0d23564c95462cfcc33f1e5108a18f578a4a7)

The following commits have unknown scopes. Please handle them manually if necessary:

- [chore(conf,ini): deno fmt](/hertzg/jsr-monorepo/commit/3a24923422d3178a4c861d29fe8913ab751caba9)
- [chore(conf,ini): deno fmt](/hertzg/jsr-monorepo/commit/3a24923422d3178a4c861d29fe8913ab751caba9)
- [chore(ini): set version to 0.1.2](/hertzg/jsr-monorepo/commit/16c582ddca7feb29aaf2cbe9a2d526c7f8d0283d)
- [chore(ini,keys): format](/hertzg/jsr-monorepo/commit/aa468224afa27747412daa0258daf5cbda97799b)
- [chore(ini,keys): format](/hertzg/jsr-monorepo/commit/aa468224afa27747412daa0258daf5cbda97799b)
- [chore(keys): remove readme](/hertzg/jsr-monorepo/commit/4aab4b9117255307719b2235a6ddcee85bbc1239)
- [chore(ini): include only mod.ts](/hertzg/jsr-monorepo/commit/efaa25bed20c5bb3c7a4cce7e03bf48d5cd86789)
- [fix(keys): only include mod.ts](/hertzg/jsr-monorepo/commit/761119902032425b38d019ac288ec262e50f1110)
- [fix(keys): jsdoc tests](/hertzg/jsr-monorepo/commit/3b50fb22cf58f40b221fe701b7633aa259f05524)

Required scopes are missing in the following commits. Please handle them manually if necessary:

- [fix: docs](/hertzg/jsr-monorepo/commit/80509832e4a238d2ca9073a81536418c608cdcfa)

The following commits are ignored:

- [chore: fix labeler](/hertzg/jsr-monorepo/commit/af265808ea29172d78a05906b41f03394685bd33)
- [chore: update versions](/hertzg/jsr-monorepo/commit/4b85c59f39814e885296c1d2094498e8f92190a8)
- [chore: deno fmt](/hertzg/jsr-monorepo/commit/18183edd41ba899803f7479ac64f2f35575c88cc)
- [chore: add vscode settings](/hertzg/jsr-monorepo/commit/e91d6de3ff327e4f9c98ee144861341bbf626e8c)
- [chore: update versions](/hertzg/jsr-monorepo/commit/2e8c06e0a98a559bcff5597d8354386874c6a632)
- [chore: install wireguard-tools needed for tests before releasing](/hertzg/jsr-monorepo/commit/bb76ef71a267a1e10320c26e42471b7ddc5d903e)
- [chore: rename labeler.yaml to .yml](/hertzg/jsr-monorepo/commit/5813fadc249aa66c1bc3cd6329c66feeb954a3db)
- [chore: update versions](/hertzg/jsr-monorepo/commit/4af380304a59964090cc450f0e6ee0b1bea6aae1)
- [chore: ignore coverage files](/hertzg/jsr-monorepo/commit/1980354675ffaee6a51476be6e2501f5ab0be15b)
- [chore: use the magic word](/hertzg/jsr-monorepo/commit/080189cc75033be78c5107c861c330da26807904)
- [chore: install wg tool on ubuntu host](/hertzg/jsr-monorepo/commit/d34769cc77102d447b1a7f7ac2e9b2bf1710a2e6)
- [chore: validate pr title](/hertzg/jsr-monorepo/commit/ad8060a8b0d991afa8124c89aab7d705936636e7)
- [chore: add publish workflow](/hertzg/jsr-monorepo/commit/7a53497e986ee18200460e93c629fdbc58632027)
- [chore: add ci for lint and test with coverage](/hertzg/jsr-monorepo/commit/8309022ba829e35da1fbf05cc07fe6f563befd99)
- [chore: ci pr-labeler](/hertzg/jsr-monorepo/commit/fcac9f0238a7f21420e6e40d9b6296013efcfc89)
- [chore: update workflow](/hertzg/jsr-monorepo/commit/4e4ba6b1d6525794534db5e469c4c223a3edefed)
- [chore: use github environment vars](/hertzg/jsr-monorepo/commit/eaa3f28e5d028f7b51d9802d3463822caeaac573)
- [chore: update setup-deno action to v2](/hertzg/jsr-monorepo/commit/43ffb8c26483a1d199f9f822fab5ec74ba452b51)

---

To make edits to this PR:

```sh
git fetch upstream release-2025-01-26-23-48-13 && git checkout -b release-2025-01-26-23-48-13 upstream/release-2025-01-26-23-48-13
```
