### PR TITLE
chore: release 2025.01.27

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,9 @@
+### 2025.01.27
+
+#### @hertzg/wg-conf 0.1.5 (patch)
+
+- chore(wg-conf): improve the examples
+
 ### 2025.01.26
 
 #### @hertzg/wg-conf 0.1.4 (patch)

--- a/import_map.json
+++ b/import_map.json
@@ -6,6 +6,6 @@
     "@noble/curves/ed25519": "jsr:@noble/curves@^1.8.1/ed25519",
     "@hertzg/wg-keys": "jsr:@hertzg/wg-keys@^0.1.4",
     "@hertzg/wg-ini": "jsr:@hertzg/wg-ini@^0.1.4",
-    "@hertzg/wg-conf": "jsr:@hertzg/wg-conf@^0.1.4"
+    "@hertzg/wg-conf": "jsr:@hertzg/wg-conf@^0.1.5"
   }
 }

--- a/wg-conf/deno.json
+++ b/wg-conf/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/wg-conf",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "exports": "./mod.ts",
   "include": [
     "mod.ts"

--- a/wg-conf/mod.ts
+++ b/wg-conf/mod.ts
@@ -124,7 +124,7 @@ export async function parse(text: string): Promise<WGQuickConf> {
                 break;
             }
             return acc;
-          }, {} as WGQuickPeer)
+          }, {} as WGQuickPeer),
         );
         break;
     }
@@ -229,8 +229,8 @@ export async function stringify(conf: WGQuickConf): Promise<string> {
       ([section, entries]) =>
         [section, entries.map(([key, value]) => [`${key} `, ` ${value}`])] as [
           string | null,
-          string[][]
-        ]
-    )
+          string[][],
+        ],
+    ),
   );
 }


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|wg-conf|0.1.4|0.1.5|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly







The following commits are ignored:

- [chore: add deno.lock to ignore](/hertzg/jsr-monorepo/commit/a01b19b43dde311fb1fe0760c3bc1ab0baefb85b)

---

To make edits to this PR:

```sh
git fetch upstream release-2025-01-27-09-50-37 && git checkout -b release-2025-01-27-09-50-37 upstream/release-2025-01-27-09-50-37
```
