### PR TITLE
chore: release 2025.01.27

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,5 +1,21 @@
 ### 2025.01.27
 
+#### @hertzg/wg-conf 0.1.6 (patch)
+
+- chore(*): remove submodules from importMap
+
+#### @hertzg/wg-ini 0.1.6 (patch)
+
+- fix(wg-ini): use relative import within the same module
+- chore(wg-ini): deno fmt
+- chore(wg-ini): remove dead links from docs
+
+#### @hertzg/wg-keys 0.1.6 (patch)
+
+- chore(*): remove submodules from importMap
+
+### 2025.01.27
+
 #### @hertzg/wg-conf 0.1.5 (patch)
 
 - chore(wg-conf): improve the examples


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@hertzg/wg-conf|0.1.5|0.1.6|patch|
|wg-ini|0.1.4|0.1.6|patch|
|@hertzg/wg-keys|0.1.4|0.1.6|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly







The following commits are ignored:

- [chore: set version](/hertzg/jsr-monorepo/commit/70aaed03003456ca67c62ee4249b3192c7291401)

---

To make edits to this PR:

```sh
git fetch upstream release-2025-01-27-17-23-55 && git checkout -b release-2025-01-27-17-23-55 upstream/release-2025-01-27-17-23-55
```
