### PR TITLE
chore: release 2025.01.27

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,5 +1,21 @@
 ### 2025.01.27
 
+#### @hertzg/wg-conf 0.1.7 (patch)
+
+- chore(*): remove submodules from importMap
+
+#### @hertzg/wg-ini 0.1.7 (patch)
+
+- fix(wg-ini): use relative import within the same module
+- chore(wg-ini): deno fmt
+- chore(wg-ini): remove dead links from docs
+
+#### @hertzg/wg-keys 0.1.7 (patch)
+
+- chore(*): remove submodules from importMap
+
+### 2025.01.27
+
 #### @hertzg/wg-conf 0.1.5 (patch)
 
 - chore(wg-conf): improve the examples

--- a/import_map.json
+++ b/import_map.json
@@ -4,8 +4,8 @@
     "@std/streams": "jsr:@std/streams@^1.0.8",
     "@noble/curves": "jsr:@noble/curves@^1.8.1",
     "@noble/curves/ed25519": "jsr:@noble/curves@^1.8.1/ed25519",
-    "@hertzg/wg-keys": "jsr:@hertzg/wg-keys@^0.1.6",
-    "@hertzg/wg-ini": "jsr:@hertzg/wg-ini@^0.1.6",
-    "@hertzg/wg-conf": "jsr:@hertzg/wg-conf@^0.1.6"
+    "@hertzg/wg-keys": "jsr:@hertzg/wg-keys@^0.1.7",
+    "@hertzg/wg-ini": "jsr:@hertzg/wg-ini@^0.1.7",
+    "@hertzg/wg-conf": "jsr:@hertzg/wg-conf@^0.1.7"
   }
 }

--- a/wg-conf/deno.json
+++ b/wg-conf/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/wg-conf",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "exports": "./mod.ts",
   "include": [
     "mod.ts"

--- a/wg-ini/deno.json
+++ b/wg-ini/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/wg-ini",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "exports": {
     ".": "./mod.ts",
     "./lines": "./lines.ts",

--- a/wg-keys/deno.json
+++ b/wg-keys/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/wg-keys",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "exports": "./mod.ts",
   "include": [
     "mod.ts"


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@hertzg/wg-conf|0.1.6|0.1.7|patch|
|wg-ini|0.1.6|0.1.7|patch|
|@hertzg/wg-keys|0.1.6|0.1.7|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly









---

To make edits to this PR:

```sh
git fetch upstream release-2025-01-27-17-37-44 && git checkout -b release-2025-01-27-17-37-44 upstream/release-2025-01-27-17-37-44
```
