### PR TITLE
chore: release 2025.01.27

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,5 +1,21 @@
 ### 2025.01.27
 
+#### @hertzg/bx 3.0.1 (major)
+
+- feat(bx): import bx package
+- chore(bx,mymagti-api): add to import_map.json
+- chore(bx): fix module graph was expcluded error
+- chore(mymagti-api,bx): add to labeler
+
+#### @hertzg/mymagti-api 0.0.4 (patch)
+
+- feat(mymagti-api): import mymagti-api project
+- chore(bx,mymagti-api): add to import_map.json
+- chore(mymagti-api,bx): add to labeler
+- chore(mymagti-api): deno fmt
+
+### 2025.01.27
+
 #### @hertzg/wg-conf 0.1.7 (patch)
 
 - chore(*): remove submodules from importMap


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|bx|0.0.0|3.0.1|major|
|mymagti-api|0.0.0|0.0.4|patch|

Please ensure:
- [x] Versions in deno.json files are updated correctly
- [x] Releases.md is updated correctly









---

To make edits to this PR:

```sh
git fetch upstream release-2025-01-27-23-35-21 && git checkout -b release-2025-01-27-23-35-21 upstream/release-2025-01-27-23-35-21
```
