### PR TITLE
chore: release 2025.03.11

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,10 @@
+### 2025.03.11
+
+#### @hertzg/binseek 0.1.0 (minor)
+
+- feat(binseek)!: shrink the module
+- fix(binseek): fix packaging
+
 ### 2025.03.10
 
 #### @hertzg/binseek 0.0.4 (patch)

--- a/binseek/deno.json
+++ b/binseek/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/binseek",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "exports": {
     ".": "./mod.ts"
   },

--- a/import_map.json
+++ b/import_map.json
@@ -8,7 +8,7 @@
     "@std/streams": "jsr:@std/streams@^1.0.8",
     "@noble/curves": "jsr:@noble/curves@^1.8.1",
     "@noble/curves/ed25519": "jsr:@noble/curves@^1.8.1/ed25519",
-    "@hertzg/binseek": "jsr:@hertzg/binseek@^0.0.4",
+    "@hertzg/binseek": "jsr:@hertzg/binseek@^0.1.0",
     "@hertzg/bx": "jsr:@hertzg/bx@^3.0.1",
     "@hertzg/mymagti-api": "jsr:@hertzg/mymagti-api@^0.0.4",
     "@hertzg/wg-keys": "jsr:@hertzg/wg-keys@^0.1.7",


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|binseek|0.0.4|0.1.0|minor|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly









---

To make edits to this PR:

```sh
git fetch upstream release-2025-03-11-00-31-50 && git checkout -b release-2025-03-11-00-31-50 upstream/release-2025-03-11-00-31-50
```
