### PR TITLE
chore: release 2025.03.11

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,5 +1,12 @@
 ### 2025.03.11
 
+#### @hertzg/binseek 0.1.1 (patch)
+
+- chore(binseek): format
+- chore(binseek): test overflow cases
+
+### 2025.03.11
+
 #### @hertzg/binseek 0.1.0 (minor)
 
 - feat(binseek)!: shrink the module

--- a/binseek/deno.json
+++ b/binseek/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/binseek",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "exports": {
     ".": "./mod.ts"
   },

--- a/import_map.json
+++ b/import_map.json
@@ -8,7 +8,7 @@
     "@std/streams": "jsr:@std/streams@^1.0.8",
     "@noble/curves": "jsr:@noble/curves@^1.8.1",
     "@noble/curves/ed25519": "jsr:@noble/curves@^1.8.1/ed25519",
-    "@hertzg/binseek": "jsr:@hertzg/binseek@^0.1.0",
+    "@hertzg/binseek": "jsr:@hertzg/binseek@^0.1.1",
     "@hertzg/bx": "jsr:@hertzg/bx@^3.0.1",
     "@hertzg/mymagti-api": "jsr:@hertzg/mymagti-api@^0.0.4",
     "@hertzg/wg-keys": "jsr:@hertzg/wg-keys@^0.1.7",


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|binseek|0.1.0|0.1.1|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly









---

To make edits to this PR:

```sh
git fetch upstream release-2025-03-11-01-00-32 && git checkout -b release-2025-03-11-01-00-32 upstream/release-2025-03-11-01-00-32
```
