### PR TITLE
chore: release 2025.07.28

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,20 @@
+### 2025.07.28
+
+#### @hertzg/binseek 0.2.0 (minor)
+
+- feat(binseek): include numeric.ts
+- feat(binseek)!: get rid of bitarray and rename .bytes() to .build()
+- feat(binseek): better type support
+- chore(binseek): rename parameter in get method for clarity
+- chore(binseek): improve type definitions for get method
+- chore(binseek): change import to type for ValueWithByteLength
+- chore(binseek): type support
+- chore(binseek): refactor code a bit
+
+#### @hertzg/binstruct 0.1.0 (minor)
+
+- feat(binstruct): introduce binstruct
+
 ### 2025.03.11
 
 #### @hertzg/binseek 0.1.1 (patch)

--- a/binseek/deno.json
+++ b/binseek/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/binseek",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "exports": {
     ".": "./mod.ts"
   },

--- a/import_map.json
+++ b/import_map.json
@@ -8,7 +8,7 @@
     "@std/streams": "jsr:@std/streams@^1.0.8",
     "@std/encoding/base64": "jsr:@std/encoding@^1.0.7/base64",
     "@std/encoding/base64url": "jsr:@std/encoding@^1.0.7/base64url",
-    "@hertzg/binseek": "jsr:@hertzg/binseek@^0.1.1",
+    "@hertzg/binseek": "jsr:@hertzg/binseek@^0.2.0",
     "@hertzg/binstruct": "jsr:@hertzg/binstruct@^0.1.0",
     "@hertzg/bx": "jsr:@hertzg/bx@^3.0.1",
     "@hertzg/mymagti-api": "jsr:@hertzg/mymagti-api@^0.0.4",


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|binseek|0.1.1|0.2.0|minor|
|binstruct|0.0.0|0.1.0|minor|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly









---

To make edits to this PR:

```sh
git fetch upstream release-2025-07-28-23-26-33 && git checkout -b release-2025-07-28-23-26-33 upstream/release-2025-07-28-23-26-33
```
