### PR TITLE
chore: release 2025.08.15

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,18 @@
+### 2025.08.15
+
+#### @hertzg/binstruct 0.1.4 (patch)
+
+- feat(binstruct): more examples
+- feat(binstruct): enhance string coder with automatic type selection and
+  comprehensive tests
+- feat(binstruct): implement unified array coder for flexible length handling
+  and add related tests
+- feat(binstruct): add computedRef function for dynamic reference calculations
+  in encoding/decoding
+- refactor(binstruct): enhance formatting and type safety in computedRef
+  function and related tests
+- chore(binstruct): remove unused import of u16le from ref.ts for cleaner code
+
 ### 2025.08.06
 
 #### @hertzg/binstruct 0.1.3 (patch)

--- a/binstruct/deno.json
+++ b/binstruct/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/binstruct",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "exports": {
     ".": "./mod.ts",
     "./numeric": "./numeric.ts",

--- a/import_map.json
+++ b/import_map.json
@@ -9,7 +9,7 @@
     "@std/encoding/base64": "jsr:@std/encoding@^1.0.10/base64",
     "@std/encoding/base64url": "jsr:@std/encoding@^1.0.10/base64url",
     "@hertzg/binseek": "jsr:@hertzg/binseek@^0.2.2",
-    "@hertzg/binstruct": "jsr:@hertzg/binstruct@^0.1.3",
+    "@hertzg/binstruct": "jsr:@hertzg/binstruct@^0.1.4",
     "@hertzg/bx": "jsr:@hertzg/bx@^3.0.1",
     "@hertzg/mymagti-api": "jsr:@hertzg/mymagti-api@^0.0.4",
     "@hertzg/wg-keys": "jsr:@hertzg/wg-keys@^1.0.0",


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|binstruct|0.1.3|0.1.4|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly







The following commits are ignored:

- [chore: update import versions for @std libraries to latest releases](/hertzg/jsr-monorepo/commit/e22dfbf84c87744ac2cfbbb3ba32bf1627b23de8)
- [chore: add release configuration for conventional commits to streamline versioning and release notes](/hertzg/jsr-monorepo/commit/f84e1d62953920f6d0b4e99177c22993393c118d)

---

To make edits to this PR:

```sh
git fetch upstream release-2025-08-15-22-52-56 && git checkout -b release-2025-08-15-22-52-56 upstream/release-2025-08-15-22-52-56
```
