### PR TITLE
chore: bump binstruct to 0.1.10-pre.1+798a04f

### DIFF
--- a/binstruct/deno.json
+++ b/binstruct/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/binstruct",
-  "version": "0.1.9",
+  "version": "0.1.10-pre.1+798a04f",
   "exports": {
     ".": "./mod.ts",
     "./numeric": "./numeric/numeric.ts",


### PR DESCRIPTION
## binstruct@0.1.10-pre.1+798a04f

- 🐛 update import paths for refSetValue and Endianness (798a04f)
