### PR TITLE
chore: bump binstruct to 0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## binstruct@0.1.10
+
+- 🐛 update import paths for refSetValue and Endianness
+
 ## bx@3.0.2
 
 - 🐛 fake fix

--- a/binstruct/deno.json
+++ b/binstruct/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/binstruct",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "exports": {
     ".": "./mod.ts",
     "./numeric": "./numeric/numeric.ts",


### PR DESCRIPTION
## binstruct@0.1.10

- 🐛 update import paths for refSetValue and Endianness (798a04f)
