### PR TITLE
chore: release 2025.10.13

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,5 +1,12 @@
 ### 2025.10.13
 
+#### @binstruct/png 0.1.2 (patch)
+
+- feat(@binstruct/png): add chunkCrc function and enhance tests for PNG chunk
+  handling
+
+### 2025.10.13
+
 #### @binstruct/ethernet 0.1.1 (minor)
 
 - feat(binstruct,@binstruct/ethernet): update binstruct module exports and add

--- a/binstruct-png/deno.json
+++ b/binstruct-png/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@binstruct/png",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "exports": {
     ".": "./mod.ts"
   },

--- a/import_map.json
+++ b/import_map.json
@@ -16,7 +16,7 @@
     "@hertzg/wg-ini": "jsr:@hertzg/wg-ini@^0.2.0",
     "@hertzg/wg-conf": "jsr:@hertzg/wg-conf@^0.2.0",
     "@binstruct/ethernet": "jsr:@binstruct/ethernet@^0.1.1",
-    "@binstruct/png": "jsr:@binstruct/png@^0.1.1",
+    "@binstruct/png": "jsr:@binstruct/png@^0.1.2",
     "@binstruct/wav": "jsr:@binstruct/wav@^0.1.1"
   }
 }


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@binstruct/png|0.1.1|0.1.2|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly







The following commits are ignored:

- [chore: update dependency management rules to allow `node:` imports](/hertzg/jsr-monorepo/commit/289747088934120bb9d663b232a1f4af68dbcb48)

---

To make edits to this PR:

```sh
git fetch upstream release-2025-10-13-15-32-11 && git checkout -b release-2025-10-13-15-32-11 upstream/release-2025-10-13-15-32-11
```
