### PR TITLE
chore: release 2025.10.25

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,26 @@
+### 2025.10.25
+
+#### @binstruct/png 0.1.3 (patch)
+
+- feat(@binstruct/png): enhance PNG file structure and chunk handling
+- fix(@binstruct/png): add context parameter to refine and unrefine methods in
+  IEND and IHDR chunk refiners for proper decoding and encoding
+- fix(@binstruct/png): include context parameter in refine and unrefine methods
+  for proper decoding and encoding
+- refactor(@binstruct/png): migrate to refineSwitch for chunk type handling
+- refactor(@binstruct/png): remove 1x1 PNG file and associated JSON metadata,
+  update idatChunkRefiner to include context parameter for decoding and encoding
+
+#### @hertzg/binstruct 3.0.0 (major)
+
+- feat(binstruct): add refineSwitch for conditional refinement and multi-stage
+  encoding/decoding
+- fix(binstruct)!: remove unused buffer parameter from refine and unrefine
+  methods
+- fix(binstruct)!: update Refiner type to use never[] for TArgs and simplify
+  function signatures
+- chore(binstruct): apply linting fixes for import ordering and formatting
+
 ### 2025.10.19
 
 #### @hertzg/binstruct 2.0.0 (major)

--- a/binstruct-png/deno.json
+++ b/binstruct-png/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@binstruct/png",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "exports": {
     ".": "./mod.ts"
   },

--- a/binstruct/deno.json
+++ b/binstruct/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/binstruct",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "exports": {
     ".": "./mod.ts",
     "./buffer": "./buffer.ts",

--- a/import_map.json
+++ b/import_map.json
@@ -11,7 +11,7 @@
     "@std/encoding/base64": "jsr:@std/encoding@^1.0.10/base64",
     "@std/encoding/base64url": "jsr:@std/encoding@^1.0.10/base64url",
     "@std/path": "jsr:@std/path@^1.0.0",
-    "@hertzg/binstruct": "jsr:@hertzg/binstruct@^2.0.0",
+    "@hertzg/binstruct": "jsr:@hertzg/binstruct@^3.0.0",
     "@hertzg/bx": "jsr:@hertzg/bx@^3.0.2",
     "@hertzg/mymagti-api": "jsr:@hertzg/mymagti-api@^0.1.0",
     "@hertzg/wg-keys": "jsr:@hertzg/wg-keys@^1.0.1",
@@ -19,7 +19,7 @@
     "@hertzg/wg-conf": "jsr:@hertzg/wg-conf@^0.2.0",
     "@binstruct/cli": "jsr:@binstruct/cli@^0.1.1",
     "@binstruct/ethernet": "jsr:@binstruct/ethernet@^0.1.1",
-    "@binstruct/png": "jsr:@binstruct/png@^0.1.2",
+    "@binstruct/png": "jsr:@binstruct/png@^0.1.3",
     "@binstruct/wav": "jsr:@binstruct/wav@^0.1.1"
   }
 }


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@binstruct/png|0.1.2|0.1.3|patch|
|binstruct|2.0.0|3.0.0|major|

Please ensure:
- [x] Versions in deno.json files are updated correctly
- [x] Releases.md is updated correctly



The following commits have unknown scopes. Please handle them manually if necessary:

- [chore(binstruct-png): add 1x1 PNG file and associated JSON metadata](/hertzg/jsr-monorepo/commit/a8cef2227efc8fbbe1de5b93565685c57ad7c4a6)



The following commits are ignored:

- [chore: add note to use deno-fmt-ignore for preserving formatting of byte arrays](/hertzg/jsr-monorepo/commit/eb22f3a7fb2a1a03a40c41176bc2132180c41566)
- [chore: replace cursor with CLAUDE](/hertzg/jsr-monorepo/commit/dc6b4859f8c1a8108e8b1ea50ac9193dc3bc9686)

---

To make edits to this PR:

```sh
git fetch upstream release-2025-10-25-21-05-21 && git checkout -b release-2025-10-25-21-05-21 upstream/release-2025-10-25-21-05-21
```
