### PR TITLE
chore: release 2025.10.25

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,5 +1,11 @@
 ### 2025.10.25
 
+#### @hertzg/binstruct 3.0.2 (patch)
+
+- chore(@hertzg/binstruct): refresh documentation guidance
+
+### 2025.10.25
+
 #### @hertzg/binstruct 3.0.1 (patch)
 
 - fix(binstruct): cross-link exported submodules in module docs\

--- a/binstruct/deno.json
+++ b/binstruct/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/binstruct",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "exports": {
     ".": "./mod.ts",
     "./buffer": "./buffer.ts",

--- a/import_map.json
+++ b/import_map.json
@@ -11,7 +11,7 @@
     "@std/encoding/base64": "jsr:@std/encoding@^1.0.10/base64",
     "@std/encoding/base64url": "jsr:@std/encoding@^1.0.10/base64url",
     "@std/path": "jsr:@std/path@^1.0.0",
-    "@hertzg/binstruct": "jsr:@hertzg/binstruct@^3.0.1",
+    "@hertzg/binstruct": "jsr:@hertzg/binstruct@^3.0.2",
     "@hertzg/bx": "jsr:@hertzg/bx@^3.0.2",
     "@hertzg/mymagti-api": "jsr:@hertzg/mymagti-api@^0.1.0",
     "@hertzg/wg-keys": "jsr:@hertzg/wg-keys@^1.0.1",


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@hertzg/binstruct|3.0.1|3.0.2|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly







The following commits are ignored:

- [chore: format](/hertzg/jsr-monorepo/commit/d5c351a2911433757301198d5e541e1ac7e9634e)
- [chore: rename to agents.md and link from claude.md](/hertzg/jsr-monorepo/commit/03bbb2a0efb6f03fa10dad764b8c9153f5b36964)

---

To make edits to this PR:

```sh
git fetch upstream release-2025-10-25-22-50-50 && git checkout -b release-2025-10-25-22-50-50 upstream/release-2025-10-25-22-50-50
```
