### PR TITLE
chore: release 2025.12.14

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,26 @@
+### 2025.12.14
+
+#### @binstruct/cli 0.1.2 (patch)
+
+- feat(@binstruct/cli): integrate JSON5 for improved serialization handling
+
+#### @binstruct/png 0.2.0 (minor)
+
+- feat(@binstruct/png): implement zlib compression and decompression
+  functionality with tests
+- feat(@binstruct/png)!: expand signature
+- feat(@binstruct/png): add PNGSuite tests
+- fix(@binstruct/png): remove unused zlibCmfFlg helper function
+- fix(@binstruct/png): decode idat payload
+- fix(@binstruct/png): update PNG signature representation to use structured
+  object
+- fix(@binstruct/png): update zlib header parsing to correctly handle checksum
+  and dictionary presence
+- fix(@binstruct/png): use same zlib functions for compression and uncompression
+- fix(@binstruct/png): update zlib import and refine data handling in
+  zlibDataRefiner
+- fix(@binstruct/png): correct import path for IdatChunk refiner
+
 ### 2025.11.14
 
 #### @hertzg/routeros-api 0.1.1 (patch)

--- a/binstruct-cli/deno.json
+++ b/binstruct-cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@binstruct/cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "exports": {
     ".": "./mod.ts",
     "./cli": "./cli.ts"

--- a/binstruct-png/deno.json
+++ b/binstruct-png/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@binstruct/png",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "exports": {
     ".": "./mod.ts"
   },

--- a/import_map.json
+++ b/import_map.json
@@ -19,9 +19,9 @@
     "@hertzg/wg-keys": "jsr:@hertzg/wg-keys@^1.0.1",
     "@hertzg/wg-ini": "jsr:@hertzg/wg-ini@^0.2.0",
     "@hertzg/wg-conf": "jsr:@hertzg/wg-conf@^0.2.0",
-    "@binstruct/cli": "jsr:@binstruct/cli@^0.1.1",
+    "@binstruct/cli": "jsr:@binstruct/cli@^0.1.2",
     "@binstruct/ethernet": "jsr:@binstruct/ethernet@^0.1.1",
-    "@binstruct/png": "jsr:@binstruct/png@^0.1.3",
+    "@binstruct/png": "jsr:@binstruct/png@^0.2.0",
     "@binstruct/wav": "jsr:@binstruct/wav@^0.1.1",
     "json5": "npm:json5@^2.2.3"
   }


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@binstruct/cli|0.1.1|0.1.2|patch|
|@binstruct/png|0.1.3|0.2.0|minor|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly







The following commits are ignored:

- [chore: disable format on save for JSON files](/hertzg/jsr-monorepo/commit/2240077875f05aa90e4b27070f70e418aa0f2a1c)

---

To make edits to this PR:

```sh
git fetch upstream release-2025-12-14-21-22-05 && git checkout -b release-2025-12-14-21-22-05 upstream/release-2025-12-14-21-22-05
```
