### PR TITLE
chore: release 2025.12.15

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,9 @@
+### 2025.12.15
+
+#### @binstruct/png 0.2.1 (patch)
+
+- fix(@binstruct/png): add pngsuite to exclude list in deno.json
+
 ### 2025.12.14
 
 #### @binstruct/cli 0.1.2 (patch)

--- a/binstruct-png/deno.json
+++ b/binstruct-png/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@binstruct/png",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "exports": {
     ".": "./mod.ts"
   },

--- a/import_map.json
+++ b/import_map.json
@@ -21,7 +21,7 @@
     "@hertzg/wg-conf": "jsr:@hertzg/wg-conf@^0.2.0",
     "@binstruct/cli": "jsr:@binstruct/cli@^0.1.2",
     "@binstruct/ethernet": "jsr:@binstruct/ethernet@^0.1.1",
-    "@binstruct/png": "jsr:@binstruct/png@^0.2.0",
+    "@binstruct/png": "jsr:@binstruct/png@^0.2.1",
     "@binstruct/wav": "jsr:@binstruct/wav@^0.1.1",
     "json5": "npm:json5@^2.2.3"
   }


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@binstruct/png|0.2.0|0.2.1|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly







The following commits are ignored:

- [chore: correct workflow name for workspace publish](/hertzg/jsr-monorepo/commit/18d79944036e738401e9068b73583c7e0da76666)

---

To make edits to this PR:

```sh
git fetch upstream release-2025-12-15-07-17-40 && git checkout -b release-2025-12-15-07-17-40 upstream/release-2025-12-15-07-17-40
```
