### PR TITLE
chore: release 2025.12.24

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,21 @@
+### 2025.12.24
+
+#### @binstruct/png 0.3.0 (minor)
+
+- feat(@binstruct/png): add bKGD chunk support with refiner and tests
+- feat(@binstruct/png)!: refactor zlib handling with bit-packed header and
+  remove legacy code
+- chore(@binstruct/png): improve code readability by formatting type definitions
+
+#### @hertzg/binstruct 3.0.3 (patch)
+
+- feat(binstruct): add support for tRNS chunk handling and associated tests
+- feat(binstruct): add bitStruct for bit-level packed field decoding
+
+#### @hertzg/ip 0.1.0 (minor)
+
+- feat(@hertzg/ip): add IPv4 and CIDR utilities with address generation
+
 ### 2025.12.15
 
 #### @binstruct/png 0.2.1 (patch)

--- a/binstruct-png/deno.json
+++ b/binstruct-png/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@binstruct/png",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "exports": {
     ".": "./mod.ts"
   },

--- a/binstruct/deno.json
+++ b/binstruct/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/binstruct",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "exports": {
     ".": "./mod.ts",
     "./bits": "./bits/mod.ts",

--- a/import_map.json
+++ b/import_map.json
@@ -12,7 +12,7 @@
     "@std/encoding/base64": "jsr:@std/encoding@^1.0.10/base64",
     "@std/encoding/base64url": "jsr:@std/encoding@^1.0.10/base64url",
     "@std/path": "jsr:@std/path@^1.0.0",
-    "@hertzg/binstruct": "jsr:@hertzg/binstruct@^3.0.2",
+    "@hertzg/binstruct": "jsr:@hertzg/binstruct@^3.0.3",
     "@hertzg/bx": "jsr:@hertzg/bx@^3.0.2",
     "@hertzg/ip": "jsr:@hertzg/ip@^0.1.0",
     "@hertzg/mymagti-api": "jsr:@hertzg/mymagti-api@^0.1.0",
@@ -22,7 +22,7 @@
     "@hertzg/wg-conf": "jsr:@hertzg/wg-conf@^0.2.0",
     "@binstruct/cli": "jsr:@binstruct/cli@^0.1.2",
     "@binstruct/ethernet": "jsr:@binstruct/ethernet@^0.1.1",
-    "@binstruct/png": "jsr:@binstruct/png@^0.2.1",
+    "@binstruct/png": "jsr:@binstruct/png@^0.3.0",
     "@binstruct/wav": "jsr:@binstruct/wav@^0.1.1",
     "json5": "npm:json5@^2.2.3"
   }


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@binstruct/png|0.2.1|0.3.0|minor|
|binstruct|3.0.2|3.0.3|patch|
|@hertzg/ip|0.0.0|0.1.0|minor|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly







The following commits are ignored:

- [chore: correct GitHub release URL formatting in release script](/hertzg/jsr-monorepo/commit/6d7460e262683beb46f906f1abb6f3eeae6e2974)

---

To make edits to this PR:

```sh
git fetch upstream release-2025-12-24-23-29-49 && git checkout -b release-2025-12-24-23-29-49 upstream/release-2025-12-24-23-29-49
```
