### PR TITLE
chore: release 2025.12.30

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,5 +1,12 @@
 ### 2025.12.30
 
+#### @hertzg/tplink-api 1.0.1 (patch)
+
+- fix(@hertzg/tplink-api): update import paths for noble ciphers and hashes to
+  include file extensions
+
+### 2025.12.30
+
 #### @hertzg/tplink-api 1.0.0 (major)
 
 - feat(@hertzg/tplink-api): enhance documentation with detailed usage examples

--- a/import_map.json
+++ b/import_map.json
@@ -19,7 +19,7 @@
     "@hertzg/ip": "jsr:@hertzg/ip@^0.1.0",
     "@hertzg/mymagti-api": "jsr:@hertzg/mymagti-api@^0.1.0",
     "@hertzg/routeros-api": "jsr:@hertzg/routeros-api@^0.1.1",
-    "@hertzg/tplink-api": "jsr:@hertzg/tplink-api@^1.0.0",
+    "@hertzg/tplink-api": "jsr:@hertzg/tplink-api@^1.0.1",
     "@hertzg/wg-keys": "jsr:@hertzg/wg-keys@^1.0.1",
     "@hertzg/wg-ini": "jsr:@hertzg/wg-ini@^0.2.0",
     "@hertzg/wg-conf": "jsr:@hertzg/wg-conf@^0.2.0",

--- a/packages/tplink-api/deno.json
+++ b/packages/tplink-api/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/tplink-api",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "exports": "./mod.ts",
   "publish": {
     "include": [


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@hertzg/tplink-api|1.0.0|1.0.1|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly







The following commits are ignored:

- [chore: update CI workflows to remove formatting checks and enhance linting tasks](/hertzg/jsr-monorepo/commit/2cdd41b983fbb6eff9dd2a25213748647e4ceb10)
- [chore: pre-push hook](/hertzg/jsr-monorepo/commit/7518575bdeebba37bd5ac9d343cc24660482656d)
- [chore: format readme](/hertzg/jsr-monorepo/commit/3ee5c243d131a22c80007e51f36c129be3d54b6c)
- [chore: monorepo restructuring](/hertzg/jsr-monorepo/commit/f47f432b478e51c6a2b3671f75610079cee517f5)
- [chore: add release process documentation with commit message format and examples](/hertzg/jsr-monorepo/commit/197e7f811c4043d22d833c2bbabc033963199580)
- [chore: add README.md with project overview, package list, and development instructions](/hertzg/jsr-monorepo/commit/fea79cd56a5a669086123f3c6297d433d3d06acf)
- [chore: update agents.md](/hertzg/jsr-monorepo/commit/39762a27f96b19fc957213c38436052ef376a5b5)

---

To make edits to this PR:

```sh
git fetch upstream release-2025-12-30-23-51-20 && git checkout -b release-2025-12-30-23-51-20 upstream/release-2025-12-30-23-51-20
```
