### PR TITLE
fix(@hertzg/tplink-api): do not re-use the cbc cipher instance

### DIFF
--- a/packages/tplink-api/client/cipher/cipher.ts
+++ b/packages/tplink-api/client/cipher/cipher.ts
@@ -33,13 +33,11 @@ export function createCipher(options: CipherOptions): Cipher {
   const iv = options.iv ?? generateKey();
   const rsaChunkSize = options.modulus.length;
 
-  const aesCipher = cbc(key, iv);
-
   return {
     key,
     iv,
-    aesEncrypt: (data: Uint8Array) => aesCipher.encrypt(data),
-    aesDecrypt: (data: Uint8Array) => aesCipher.decrypt(data),
+    aesEncrypt: (data: Uint8Array) => cbc(key, iv).encrypt(data),
+    aesDecrypt: (data: Uint8Array) => cbc(key, iv).decrypt(data),
     rsaEncrypt: (data: Uint8Array) => {
       const chunkCount = Math.ceil(data.length / rsaChunkSize);
       const encryptedChunks: Uint8Array[] = [];


### PR DESCRIPTION
Fixes #66 

## Summary

- Fixes AES cipher re-use issue where subsequent encrypt/decrypt calls would fail or produce incorrect results
- The `@noble/ciphers` CBC cipher maintains internal state and cannot be reused after encryption/decryption
- Now creates a fresh cipher instance for each operation instead of reusing a single instance

## Test plan

- [x] Added test verifying multiple encryptions with the same `Cipher` instance work correctly
- [x] Test verifies decryption of all encrypted messages returns original plaintext
- [x] All existing tests pass