### PR TITLE
chore: release 2025.12.31

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,9 @@
+### 2025.12.31
+
+#### @hertzg/tplink-api 1.0.2 (patch)
+
+- fix(@hertzg/tplink-api): do not re-use the cbc cipher instance (#68)
+
 ### 2025.12.30
 
 #### @hertzg/tplink-api 1.0.1 (patch)

--- a/import_map.json
+++ b/import_map.json
@@ -19,7 +19,7 @@
     "@hertzg/ip": "jsr:@hertzg/ip@^0.1.0",
     "@hertzg/mymagti-api": "jsr:@hertzg/mymagti-api@^0.1.0",
     "@hertzg/routeros-api": "jsr:@hertzg/routeros-api@^0.1.1",
-    "@hertzg/tplink-api": "jsr:@hertzg/tplink-api@^1.0.1",
+    "@hertzg/tplink-api": "jsr:@hertzg/tplink-api@^1.0.2",
     "@hertzg/wg-keys": "jsr:@hertzg/wg-keys@^1.0.1",
     "@hertzg/wg-ini": "jsr:@hertzg/wg-ini@^0.2.0",
     "@hertzg/wg-conf": "jsr:@hertzg/wg-conf@^0.2.0",

--- a/packages/tplink-api/deno.json
+++ b/packages/tplink-api/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/tplink-api",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "exports": "./mod.ts",
   "publish": {
     "include": [


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@hertzg/tplink-api|1.0.1|1.0.2|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly







The following commits are ignored:

- [chore: refactor import handling and add dependency snapshot tests (#67)](/hertzg/jsr-monorepo/commit/c4c7992838fb0919ddede93048cdeff561f9c94c)

---

To make edits to this PR:

```sh
git fetch upstream release-2025-12-31-10-36-33 && git checkout -b release-2025-12-31-10-36-33 upstream/release-2025-12-31-10-36-33
```
