### PR TITLE
feat(@binstruct/png): use @hertzg/crc for CRC32 calculation

### DIFF
--- a/packages/binstruct-png/_deps.snap
+++ b/packages/binstruct-png/_deps.snap
@@ -2,6 +2,9 @@ export const snapshot = {};
 
 snapshot[`dependencies > @binstruct/png 1`] = `
 [
+  "https://jsr.io/@std/cache/0.2.1/_serialize_arg_list.ts",
+  "https://jsr.io/@std/cache/0.2.1/lru_cache.ts",
+  "https://jsr.io/@std/cache/0.2.1/memoize.ts",
   "node:zlib",
 ]
 `;

--- a/packages/binstruct-png/mod.ts
+++ b/packages/binstruct-png/mod.ts
@@ -57,7 +57,7 @@ import {
   u32be,
   u8,
 } from "@hertzg/binstruct";
-import { crc32 } from "node:zlib";
+import { crc32 } from "@hertzg/crc";
 import { type IhdrChunk, ihdrChunkRefiner } from "./chunks/ihdr.ts";
 import { type IdatChunk, idatChunkRefiner } from "./chunks/idat.ts";
 import { type IendChunk, iendChunkRefiner } from "./chunks/iend.ts";


### PR DESCRIPTION
## Summary
- Replace `node:zlib` crc32 import with `@hertzg/crc` for CRC32 checksum calculation
- Both implementations use the same ISO 3309 polynomial (used by PNG/ZIP/gzip)
- Note: The package still uses `node:zlib` for deflate/inflate compression operations

## Test plan
- [x] All existing tests pass
- [x] CRC calculations produce identical results