### PR TITLE
chore: release 2025.12.31

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,5 +1,12 @@
 ### 2025.12.31
 
+#### @binstruct/png 0.3.2 (patch)
+
+- feat(@binstruct/png): replace node:zlib with fflate for compression (#73)
+- feat(@binstruct/png): use @hertzg/crc for CRC32 calculation (#72)
+
+### 2025.12.31
+
 #### @binstruct/cli 0.1.3 (patch)
 
 - chore(*): freeze the versions

--- a/import_map.json
+++ b/import_map.json
@@ -27,7 +27,7 @@
     "@hertzg/wg-conf": "jsr:@hertzg/wg-conf@^0.2.1",
     "@binstruct/cli": "jsr:@binstruct/cli@^0.1.3",
     "@binstruct/ethernet": "jsr:@binstruct/ethernet@^0.1.2",
-    "@binstruct/png": "jsr:@binstruct/png@^0.3.1",
+    "@binstruct/png": "jsr:@binstruct/png@^0.3.2",
     "@binstruct/wav": "jsr:@binstruct/wav@^0.1.2",
     "json5": "npm:json5@^2.2.3",
     "fflate": "npm:fflate@0.8.2",

--- a/packages/binstruct-png/deno.json
+++ b/packages/binstruct-png/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@binstruct/png",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "exports": {
     ".": "./mod.ts"
   },


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@binstruct/png|0.3.1|0.3.2|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly









---

To make edits to this PR:

```sh
git fetch upstream release-2025-12-31-18-25-48 && git checkout -b release-2025-12-31-18-25-48 upstream/release-2025-12-31-18-25-48
```
