### PR TITLE
chore(@hertzg/wg-ctl): remove references to non-existent package

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -37,9 +37,6 @@
 "@hertzg/wg-keys":
   - changed-files:
       - any-glob-to-any-file: packages/wg-keys/**
-"@hertzg/wg-ctl":
-  - changed-files:
-      - any-glob-to-any-file: packages/wg-ctl/**
 "@hertzg/crc":
   - changed-files:
       - any-glob-to-any-file: packages/crc/**

--- a/.github/workflows/title.yaml
+++ b/.github/workflows/title.yaml
@@ -44,6 +44,5 @@ jobs:
             @hertzg/routeros-api
             @hertzg/tplink-api
             @hertzg/wg-conf
-            @hertzg/wg-ctl
             @hertzg/wg-ini
             @hertzg/wg-keys

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,6 @@ All packages are located in the `packages/` directory:
 - `packages/wg-keys` - WireGuard key management
 - `packages/wg-ini` - INI file parsing
 - `packages/wg-conf` - WireGuard configuration handling
-- `packages/wg-ctl` - WireGuard control library (wg-quick parity)
 - `packages/routeros-api` - MikroTik RouterOS API client
 - `packages/tplink-api` - TP-Link Router API client
 - `packages/mymagti-api` - MyMagti API client
@@ -328,7 +327,6 @@ both tiresome and error-prone.
 - `@hertzg/wg-keys`
 - `@hertzg/wg-ini`
 - `@hertzg/wg-conf`
-- `@hertzg/wg-ctl`
 - `@hertzg/mymagti-api`
 - `@hertzg/bx`
 - `@hertzg/ip`

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ libraries, format-specific parsers, router API clients, and various utilities.
 | [@hertzg/wg-conf](https://jsr.io/@hertzg/wg-conf)           | [![JSR](https://jsr.io/badges/@hertzg/wg-conf)](https://jsr.io/@hertzg/wg-conf)           |
 | [@hertzg/wg-ini](https://jsr.io/@hertzg/wg-ini)             | [![JSR](https://jsr.io/badges/@hertzg/wg-ini)](https://jsr.io/@hertzg/wg-ini)             |
 | [@hertzg/wg-keys](https://jsr.io/@hertzg/wg-keys)           | [![JSR](https://jsr.io/badges/@hertzg/wg-keys)](https://jsr.io/@hertzg/wg-keys)           |
-| [@hertzg/wg-ctl](https://jsr.io/@hertzg/wg-ctl)             | [![JSR](https://jsr.io/badges/@hertzg/wg-ctl)](https://jsr.io/@hertzg/wg-ctl)             |
 | [@binstruct/cli](https://jsr.io/@binstruct/cli)             | [![JSR](https://jsr.io/badges/@binstruct/cli)](https://jsr.io/@binstruct/cli)             |
 | [@binstruct/ethernet](https://jsr.io/@binstruct/ethernet)   | [![JSR](https://jsr.io/badges/@binstruct/ethernet)](https://jsr.io/@binstruct/ethernet)   |
 | [@binstruct/png](https://jsr.io/@binstruct/png)             | [![JSR](https://jsr.io/badges/@binstruct/png)](https://jsr.io/@binstruct/png)             |

--- a/import_map.json
+++ b/import_map.json
@@ -25,7 +25,6 @@
     "@hertzg/wg-keys": "jsr:@hertzg/wg-keys@^1.0.2",
     "@hertzg/wg-ini": "jsr:@hertzg/wg-ini@^0.2.1",
     "@hertzg/wg-conf": "jsr:@hertzg/wg-conf@^0.2.1",
-    "@hertzg/wg-ctl": "jsr:@hertzg/wg-ctl@^0.1.0",
     "@binstruct/cli": "jsr:@binstruct/cli@^0.1.3",
     "@binstruct/ethernet": "jsr:@binstruct/ethernet@^0.1.2",
     "@binstruct/png": "jsr:@binstruct/png@^0.3.2",


### PR DESCRIPTION
## Summary
The `@hertzg/wg-ctl` package was listed in config files but never existed in this repo. This PR removes all references:
- `import_map.json`
- `README.md`
- `AGENTS.md` (workspaces list and valid scopes)
- `.github/workflows/title.yaml`
- `.github/labeler.yml`

## Test plan
- [x] `deno task lint` passes
- [x] `deno task test` passes