### PR TITLE
fix(@hertzg/wg-ini): improve JSDoc documentation

### DIFF
--- a/packages/wg-ini/lines.ts
+++ b/packages/wg-ini/lines.ts
@@ -1,42 +1,95 @@
 /**
- * Transform streams for encoding and decoding lines of an INI file.
+ * Transform streams for encoding and decoding individual lines of an INI file.
  *
- * See {@link IniLineDecoderStream} and {@link IniLineEncoderStream} for more information.
+ * This module provides low-level stream transformers that work with individual
+ * lines of INI text. Use {@link IniLineDecoderStream} to parse text lines into
+ * structured {@link IniLine} objects, and {@link IniLineEncoderStream} to convert
+ * them back to text.
+ *
+ * For higher-level section-based processing, see the `sections` module.
+ * For convenient parse/stringify functions, see the main module.
+ *
+ * @example Decode and encode INI lines
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { IniLineDecoderStream, IniLineEncoderStream } from "@hertzg/wg-ini/lines";
+ *
+ * const lines = ["[section]", "key=value"];
+ * const decoded = await Array.fromAsync(
+ *   ReadableStream.from(lines).pipeThrough(new IniLineDecoderStream())
+ * );
+ *
+ * assertEquals(decoded, [
+ *   { $section: "section", $trailer: "" },
+ *   { $assign: ["key", "value"], $comment: null },
+ * ]);
+ *
+ * const encoded = await Array.fromAsync(
+ *   ReadableStream.from(decoded).pipeThrough(new IniLineEncoderStream())
+ * );
+ *
+ * assertEquals(encoded, lines);
+ * ```
  *
  * @module
  */
+
+/**
+ * Configuration options for {@link IniLineDecoderStream}.
+ */
 export interface IniLineDecoderStreamOptions {
-  /** Delimiter for comments (default: "#") */
+  /** Delimiter for comments (default: `"#"`). */
   commentDelimiter?: string;
-  /** Delimiter for section start (default: "[") */
+  /** Delimiter for section start (default: `"["`). */
   sectionStartDelimiter?: string;
-  /** Delimiter for section end (default: "]") */
+  /** Delimiter for section end (default: `"]"`). */
   sectionEndDelimiter?: string;
-  /** Delimiter for key-value pairs (default: "=") */
+  /** Delimiter for key-value pairs (default: `"="`). */
   keyValueDelimiter?: string;
 }
 
 /**
- * Represents an INI section line.
+ * Represents an INI section header line (e.g., `[section]`).
+ *
+ * The `$section` property contains the section name without brackets.
+ * The optional `$trailer` contains any text after the closing bracket.
  */
 export type IniLineSection = { $section: string; $trailer?: string };
+
 /**
- * Represents an INI key-value assignment line.
+ * Represents an INI key-value assignment line (e.g., `key=value`).
+ *
+ * The `$assign` property is a tuple of `[key, value]`.
+ * The optional `$comment` contains any inline comment after the value,
+ * or `null` if no comment delimiter was found.
  */
 export type IniLineAssign = {
   $assign: [string, string];
   $comment?: string | null;
 };
+
 /**
- * Represents an INI comment line.
+ * Represents an INI comment line (e.g., `# comment`).
+ *
+ * The `$comment` property contains the comment text without the delimiter.
  */
 export type IniLineComment = { $comment: string };
+
 /**
- * Represents an INI trailer line.
+ * Represents an INI trailer line (empty lines or unrecognized content).
+ *
+ * The `$trailer` property contains the raw line content.
  */
 export type IniLineTrailer = { $trailer: string };
+
 /**
  * Union type for all INI line types.
+ *
+ * Each line in an INI file is parsed into one of these types:
+ * - {@link IniLineSection}: Section headers like `[section]`
+ * - {@link IniLineAssign}: Key-value pairs like `key=value`
+ * - {@link IniLineComment}: Comment lines like `# comment`
+ * - {@link IniLineTrailer}: Empty lines or unrecognized content
  */
 export type IniLine =
   | IniLineSection
@@ -46,93 +99,60 @@ export type IniLine =
 
 /**
  * A transform stream that decodes lines of an INI file into structured objects.
- * Differentiates between comments, sections, key-value pairs, and trailers.
  *
- * Comments are lines that start with a comment delimiter.
- * Sections are lines that start with a section start delimiter, contain a section end delimiter, and may have a trailer (comment).
- * Key-value pairs are lines that contain a key-value delimiter and may have a comment.
- * Trailers are lines that do not match any of the above (eg: spaces in between sections and/or key-value pairs).
+ * Parses each input line and emits one of four line types:
+ * - {@link IniLineComment}: Lines starting with the comment delimiter
+ * - {@link IniLineSection}: Lines with section brackets (e.g., `[section]`)
+ * - {@link IniLineAssign}: Lines with key-value pairs (e.g., `key=value`)
+ * - {@link IniLineTrailer}: Empty lines or unrecognized content
  *
- * Since this processes stream line by line, it can handle duplicate keys and duplicate sections as well as their comments.
+ * Since this processes line by line, it preserves duplicate keys and sections.
+ * Input chunks are expected to be individual lines of text (use `TextLineStream`
+ * to split text into lines first).
  *
- * This stream chunks are expected to be lines of text.
- *
- * @example INI Lines
+ * @example Decode INI lines with various content types
  * ```ts
- * import { TextLineStream } from "@std/streams";
  * import { assertEquals } from "@std/assert";
  * import { IniLineDecoderStream } from "@hertzg/wg-ini/lines";
  *
  * const stream = ReadableStream.from([
- *  "# comment outside of section",
- *  "global_key=global_value # with comment",
- *  "duplicated=key",
- *  "duplicated=with other value",
- *  "[empty]",
- *  "[section with spaces] # and a comment",
- *  "key1=1",
- *  "key2=2",
- *  "[duplicated section]",
- *  "key1=1",
- *  "[duplicated section]",
- *  "key1=2"
+ *   "# comment outside of section",
+ *   "global_key=global_value # with comment",
+ *   "duplicated=key",
+ *   "duplicated=with other value",
+ *   "[empty]",
+ *   "[section with spaces] # and a comment",
+ *   "key1=1",
+ *   "key2=2",
+ *   "[duplicated section]",
+ *   "key1=1",
+ *   "[duplicated section]",
+ *   "key1=2",
  * ]).pipeThrough(new IniLineDecoderStream());
  *
  * const lines = await Array.fromAsync(stream);
  *
  * assertEquals(lines, [
  *   { $comment: " comment outside of section" },
- *   {
- *     $assign: ["global_key", "global_value "],
- *     $comment: " with comment",
- *   },
- *   {
- *     $assign: ["duplicated", "key"],
- *     $comment: null,
- *   },
- *   {
- *     $assign: ["duplicated", "with other value"],
- *     $comment: null,
- *   },
- *   {
- *     $section: "empty",
- *     $trailer: "",
- *   },
- *   {
- *     $section: "section with spaces",
- *     $trailer: " # and a comment",
- *   },
- *   {
- *     $assign: ["key1", "1"],
- *     $comment: null,
- *   },
- *   {
- *     $assign: ["key2", "2"],
- *     $comment: null,
- *   },
- *   {
- *     $section: "duplicated section",
- *     $trailer: "",
- *   },
- *   {
- *     $assign: ["key1", "1"],
- *     $comment: null,
- *   },
- *   {
- *     $section: "duplicated section",
- *     $trailer: "",
- *   },
- *   {
- *     $assign: ["key1", "2"],
- *     $comment: null,
- *   }
+ *   { $assign: ["global_key", "global_value "], $comment: " with comment" },
+ *   { $assign: ["duplicated", "key"], $comment: null },
+ *   { $assign: ["duplicated", "with other value"], $comment: null },
+ *   { $section: "empty", $trailer: "" },
+ *   { $section: "section with spaces", $trailer: " # and a comment" },
+ *   { $assign: ["key1", "1"], $comment: null },
+ *   { $assign: ["key2", "2"], $comment: null },
+ *   { $section: "duplicated section", $trailer: "" },
+ *   { $assign: ["key1", "1"], $comment: null },
+ *   { $section: "duplicated section", $trailer: "" },
+ *   { $assign: ["key1", "2"], $comment: null },
  * ]);
  * ```
  */
 export class IniLineDecoderStream extends TransformStream<string, IniLine> {
   /**
-   * Creates a new INI line decoder stream.
-   * @param options - Configuration options for the decoder
+   * Create a new INI line decoder stream.
+   *
+   * @param options Configuration options for parsing delimiters.
    */
   constructor(options: IniLineDecoderStreamOptions = {}) {
     const {
@@ -179,40 +199,43 @@ export class IniLineDecoderStream extends TransformStream<string, IniLine> {
 }
 
 /**
- * Options for the INI line encoder stream.
+ * Configuration options for {@link IniLineEncoderStream}.
  */
 export interface IniLineEncoderStreamOptions {
-  /** Delimiter for comments (default: "#") */
+  /** Delimiter for comments (default: `"#"`). */
   commentDelimiter?: string;
-  /** Delimiter for section start (default: "[") */
+  /** Delimiter for section start (default: `"["`). */
   sectionStartDelimiter?: string;
-  /** Delimiter for section end (default: "]") */
+  /** Delimiter for section end (default: `"]"`). */
   sectionEndDelimiter?: string;
-  /** Delimiter for key-value pairs (default: "=") */
+  /** Delimiter for key-value pairs (default: `"="`). */
   keyValueDelimiter?: string;
 }
 
 /**
- * A transform stream that encodes ini line structured objects (back) into lines of an INI file.
- * This does the opposite of {@link IniLineDecoderStream} while trying to maintain the original format.
+ * A transform stream that encodes INI line objects back into text lines.
  *
- * @example
+ * This is the reverse of {@link IniLineDecoderStream}. It converts structured
+ * {@link IniLine} objects back into their string representation, preserving
+ * comments and trailers.
+ *
+ * @example Encode INI line objects to text
  * ```ts
  * import { assertEquals } from "@std/assert";
  * import { IniLineEncoderStream, type IniLine } from "@hertzg/wg-ini/lines";
  *
  * const stream = ReadableStream.from([
- *  { $comment: " comment outside of section" },
- *  { $assign: ["global_key", "global_value "], $comment: " with comment" },
- *  { $trailer: "" },
- *  { $section: "mysection" },
- *  { $assign: ["key1", "1"] },
- *  { $assign: ["key2", "2"] },
- *  { $trailer: "" },
- *  { $section: "mysection", $trailer: " # and a comment" },
- *  { $assign: ["key1", "3"] },
- *  { $assign: ["key2", "4"] },
- *  { $trailer: "" }
+ *   { $comment: " comment outside of section" },
+ *   { $assign: ["global_key", "global_value "], $comment: " with comment" },
+ *   { $trailer: "" },
+ *   { $section: "mysection" },
+ *   { $assign: ["key1", "1"] },
+ *   { $assign: ["key2", "2"] },
+ *   { $trailer: "" },
+ *   { $section: "mysection", $trailer: " # and a comment" },
+ *   { $assign: ["key1", "3"] },
+ *   { $assign: ["key2", "4"] },
+ *   { $trailer: "" },
  * ] as IniLine[]).pipeThrough(new IniLineEncoderStream());
  *
  * const lines = await Array.fromAsync(stream);
@@ -233,8 +256,9 @@ export interface IniLineEncoderStreamOptions {
  */
 export class IniLineEncoderStream extends TransformStream<IniLine, string> {
   /**
-   * Creates a new INI line encoder stream.
-   * @param options - Configuration options for the encoder
+   * Create a new INI line encoder stream.
+   *
+   * @param options Configuration options for encoding delimiters.
    */
   constructor(options: IniLineEncoderStreamOptions = {}) {
     const {


### PR DESCRIPTION
## Summary
- Add proper `@module` tag placement in all files
- Add `@param` and `@returns` tags to all exported functions
- Improve type documentation with detailed descriptions
- Add comprehensive examples with assertions
- Fix module-level JSDoc in sections.ts (was incorrectly placed after type definition)

## Test plan
- [x] `deno task lint` passes
- [x] `deno task test` passes
- [x] All JSDoc examples are executable and tested