### PR TITLE
chore: release 2026.01.03

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,5 +1,11 @@
 ### 2026.01.03
 
+#### @hertzg/wg-ini 0.2.2 (patch)
+
+- fix(@hertzg/wg-ini): improve JSDoc documentation (#83)
+
+### 2026.01.03
+
 #### @binstruct/png 0.3.3 (patch)
 
 - fix(@binstruct/png): add missing JSDoc documentation (#78)

--- a/import_map.json
+++ b/import_map.json
@@ -23,7 +23,7 @@
     "@hertzg/routeros-api": "jsr:@hertzg/routeros-api@^0.1.2",
     "@hertzg/tplink-api": "jsr:@hertzg/tplink-api@^1.0.4",
     "@hertzg/wg-keys": "jsr:@hertzg/wg-keys@^1.0.3",
-    "@hertzg/wg-ini": "jsr:@hertzg/wg-ini@^0.2.1",
+    "@hertzg/wg-ini": "jsr:@hertzg/wg-ini@^0.2.2",
     "@hertzg/wg-conf": "jsr:@hertzg/wg-conf@^0.2.2",
     "@hertzg/wg-ctl": "jsr:@hertzg/wg-ctl@^0.1.0",
     "@binstruct/cli": "jsr:@binstruct/cli@^0.1.3",

--- a/packages/wg-ini/deno.json
+++ b/packages/wg-ini/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/wg-ini",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "exports": {
     ".": "./mod.ts",
     "./lines": "./lines.ts",


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@hertzg/wg-ini|0.2.1|0.2.2|patch|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly









---

To make edits to this PR:

```sh
git fetch upstream release-2026-01-03-18-52-00 && git checkout -b release-2026-01-03-18-52-00 upstream/release-2026-01-03-18-52-00
```
