### PR TITLE
chore: improve dependency snapshot to track direct deps with semver ranges

### DIFF
--- a/packages/binstruct-cli/_deps.snap
+++ b/packages/binstruct-cli/_deps.snap
@@ -2,28 +2,16 @@ export const snapshot = {};
 
 snapshot[`dependencies > @binstruct/cli 1`] = `
 [
-  "https://jsr.io/@std/cli/1.0.25/_data.json",
-  "https://jsr.io/@std/cli/1.0.25/_run_length.ts",
-  "https://jsr.io/@std/cli/1.0.25/mod.ts",
-  "https://jsr.io/@std/cli/1.0.25/parse_args.ts",
-  "https://jsr.io/@std/cli/1.0.25/prompt_secret.ts",
-  "https://jsr.io/@std/cli/1.0.25/unicode_width.ts",
-  "https://jsr.io/@std/internal/1.0.12/_os.ts",
-  "https://jsr.io/@std/internal/1.0.12/os.ts",
-  "npm:/json5@2.2.3",
+  "jsr:@std/cli@^1.0.25",
+  "@hertzg/binstruct",
+  "npm:json5@^2.2.3",
 ]
 `;
 
 snapshot[`dependencies > @binstruct/cli 2`] = `
 [
-  "https://jsr.io/@std/cli/1.0.25/_data.json",
-  "https://jsr.io/@std/cli/1.0.25/_run_length.ts",
-  "https://jsr.io/@std/cli/1.0.25/mod.ts",
-  "https://jsr.io/@std/cli/1.0.25/parse_args.ts",
-  "https://jsr.io/@std/cli/1.0.25/prompt_secret.ts",
-  "https://jsr.io/@std/cli/1.0.25/unicode_width.ts",
-  "https://jsr.io/@std/internal/1.0.12/_os.ts",
-  "https://jsr.io/@std/internal/1.0.12/os.ts",
-  "npm:/json5@2.2.3",
+  "jsr:@std/cli@^1.0.25",
+  "@hertzg/binstruct",
+  "npm:json5@^2.2.3",
 ]
 `;

--- a/packages/binstruct-ethernet/_deps.snap
+++ b/packages/binstruct-ethernet/_deps.snap
@@ -1,3 +1,7 @@
 export const snapshot = {};
 
-snapshot[`dependencies > @binstruct/ethernet 1`] = `[]`;
+snapshot[`dependencies > @binstruct/ethernet 1`] = `
+[
+  "@hertzg/binstruct",
+]
+`;

--- a/packages/binstruct-png/_deps.snap
+++ b/packages/binstruct-png/_deps.snap
@@ -2,9 +2,8 @@ export const snapshot = {};
 
 snapshot[`dependencies > @binstruct/png 1`] = `
 [
-  "https://jsr.io/@std/cache/0.2.1/_serialize_arg_list.ts",
-  "https://jsr.io/@std/cache/0.2.1/lru_cache.ts",
-  "https://jsr.io/@std/cache/0.2.1/memoize.ts",
-  "npm:/fflate@0.8.2",
+  "@hertzg/binstruct",
+  "@hertzg/crc",
+  "npm:fflate@0.8.2",
 ]
 `;

--- a/packages/binstruct-wav/_deps.snap
+++ b/packages/binstruct-wav/_deps.snap
@@ -1,3 +1,7 @@
 export const snapshot = {};
 
-snapshot[`dependencies > @binstruct/wav 1`] = `[]`;
+snapshot[`dependencies > @binstruct/wav 1`] = `
+[
+  "@hertzg/binstruct",
+]
+`;

--- a/packages/crc/_deps.snap
+++ b/packages/crc/_deps.snap
@@ -2,40 +2,30 @@ export const snapshot = {};
 
 snapshot[`dependencies > @hertzg/crc 1`] = `
 [
-  "https://jsr.io/@std/cache/0.2.1/_serialize_arg_list.ts",
-  "https://jsr.io/@std/cache/0.2.1/lru_cache.ts",
-  "https://jsr.io/@std/cache/0.2.1/memoize.ts",
+  "jsr:@std/cache@0.2.1/memoize",
 ]
 `;
 
 snapshot[`dependencies > @hertzg/crc 2`] = `
 [
-  "https://jsr.io/@std/cache/0.2.1/_serialize_arg_list.ts",
-  "https://jsr.io/@std/cache/0.2.1/lru_cache.ts",
-  "https://jsr.io/@std/cache/0.2.1/memoize.ts",
+  "jsr:@std/cache@0.2.1/memoize",
 ]
 `;
 
 snapshot[`dependencies > @hertzg/crc 3`] = `
 [
-  "https://jsr.io/@std/cache/0.2.1/_serialize_arg_list.ts",
-  "https://jsr.io/@std/cache/0.2.1/lru_cache.ts",
-  "https://jsr.io/@std/cache/0.2.1/memoize.ts",
+  "jsr:@std/cache@0.2.1/memoize",
 ]
 `;
 
 snapshot[`dependencies > @hertzg/crc 4`] = `
 [
-  "https://jsr.io/@std/cache/0.2.1/_serialize_arg_list.ts",
-  "https://jsr.io/@std/cache/0.2.1/lru_cache.ts",
-  "https://jsr.io/@std/cache/0.2.1/memoize.ts",
+  "jsr:@std/cache@0.2.1/memoize",
 ]
 `;
 
 snapshot[`dependencies > @hertzg/crc 5`] = `
 [
-  "https://jsr.io/@std/cache/0.2.1/_serialize_arg_list.ts",
-  "https://jsr.io/@std/cache/0.2.1/lru_cache.ts",
-  "https://jsr.io/@std/cache/0.2.1/memoize.ts",
+  "jsr:@std/cache@0.2.1/memoize",
 ]
 `;

--- a/packages/tplink-api/_deps.snap
+++ b/packages/tplink-api/_deps.snap
@@ -2,11 +2,7 @@ export const snapshot = {};
 
 snapshot[`dependencies > @hertzg/tplink-api 1`] = `
 [
-  "https://jsr.io/@noble/ciphers/2.1.1/src/_polyval.ts",
-  "https://jsr.io/@noble/ciphers/2.1.1/src/aes.ts",
-  "https://jsr.io/@noble/ciphers/2.1.1/src/utils.ts",
-  "https://jsr.io/@noble/hashes/2.0.1/src/_md.ts",
-  "https://jsr.io/@noble/hashes/2.0.1/src/legacy.ts",
-  "https://jsr.io/@noble/hashes/2.0.1/src/utils.ts",
+  "jsr:@noble/ciphers@^2.1.1/aes.js",
+  "jsr:@noble/hashes@^2.0.1/legacy.js",
 ]
 `;

--- a/packages/wg-conf/_deps.snap
+++ b/packages/wg-conf/_deps.snap
@@ -2,26 +2,6 @@ export const snapshot = {};
 
 snapshot[`dependencies > @hertzg/wg-conf 1`] = `
 [
-  "https://jsr.io/@std/bytes/1.0.6/_types.ts",
-  "https://jsr.io/@std/bytes/1.0.6/concat.ts",
-  "https://jsr.io/@std/bytes/1.0.6/copy.ts",
-  "https://jsr.io/@std/streams/1.0.16/_common.ts",
-  "https://jsr.io/@std/streams/1.0.16/buffer.ts",
-  "https://jsr.io/@std/streams/1.0.16/byte_slice_stream.ts",
-  "https://jsr.io/@std/streams/1.0.16/concat_readable_streams.ts",
-  "https://jsr.io/@std/streams/1.0.16/delimiter_stream.ts",
-  "https://jsr.io/@std/streams/1.0.16/early_zip_readable_streams.ts",
-  "https://jsr.io/@std/streams/1.0.16/limited_bytes_transform_stream.ts",
-  "https://jsr.io/@std/streams/1.0.16/limited_transform_stream.ts",
-  "https://jsr.io/@std/streams/1.0.16/merge_readable_streams.ts",
-  "https://jsr.io/@std/streams/1.0.16/mod.ts",
-  "https://jsr.io/@std/streams/1.0.16/text_delimiter_stream.ts",
-  "https://jsr.io/@std/streams/1.0.16/text_line_stream.ts",
-  "https://jsr.io/@std/streams/1.0.16/to_array_buffer.ts",
-  "https://jsr.io/@std/streams/1.0.16/to_blob.ts",
-  "https://jsr.io/@std/streams/1.0.16/to_json.ts",
-  "https://jsr.io/@std/streams/1.0.16/to_text.ts",
-  "https://jsr.io/@std/streams/1.0.16/to_transform_stream.ts",
-  "https://jsr.io/@std/streams/1.0.16/zip_readable_streams.ts",
+  "@hertzg/wg-ini",
 ]
 `;

--- a/packages/wg-ini/_deps.snap
+++ b/packages/wg-ini/_deps.snap
@@ -2,27 +2,7 @@ export const snapshot = {};
 
 snapshot[`dependencies > @hertzg/wg-ini 1`] = `
 [
-  "https://jsr.io/@std/bytes/1.0.6/_types.ts",
-  "https://jsr.io/@std/bytes/1.0.6/concat.ts",
-  "https://jsr.io/@std/bytes/1.0.6/copy.ts",
-  "https://jsr.io/@std/streams/1.0.16/_common.ts",
-  "https://jsr.io/@std/streams/1.0.16/buffer.ts",
-  "https://jsr.io/@std/streams/1.0.16/byte_slice_stream.ts",
-  "https://jsr.io/@std/streams/1.0.16/concat_readable_streams.ts",
-  "https://jsr.io/@std/streams/1.0.16/delimiter_stream.ts",
-  "https://jsr.io/@std/streams/1.0.16/early_zip_readable_streams.ts",
-  "https://jsr.io/@std/streams/1.0.16/limited_bytes_transform_stream.ts",
-  "https://jsr.io/@std/streams/1.0.16/limited_transform_stream.ts",
-  "https://jsr.io/@std/streams/1.0.16/merge_readable_streams.ts",
-  "https://jsr.io/@std/streams/1.0.16/mod.ts",
-  "https://jsr.io/@std/streams/1.0.16/text_delimiter_stream.ts",
-  "https://jsr.io/@std/streams/1.0.16/text_line_stream.ts",
-  "https://jsr.io/@std/streams/1.0.16/to_array_buffer.ts",
-  "https://jsr.io/@std/streams/1.0.16/to_blob.ts",
-  "https://jsr.io/@std/streams/1.0.16/to_json.ts",
-  "https://jsr.io/@std/streams/1.0.16/to_text.ts",
-  "https://jsr.io/@std/streams/1.0.16/to_transform_stream.ts",
-  "https://jsr.io/@std/streams/1.0.16/zip_readable_streams.ts",
+  "jsr:@std/streams@^1.0.16",
 ]
 `;
 

--- a/packages/wg-keys/_deps.snap
+++ b/packages/wg-keys/_deps.snap
@@ -2,10 +2,7 @@ export const snapshot = {};
 
 snapshot[`dependencies > @hertzg/wg-keys 1`] = `
 [
-  "https://jsr.io/@std/encoding/1.0.10/_common64.ts",
-  "https://jsr.io/@std/encoding/1.0.10/_common_detach.ts",
-  "https://jsr.io/@std/encoding/1.0.10/_types.ts",
-  "https://jsr.io/@std/encoding/1.0.10/base64.ts",
-  "https://jsr.io/@std/encoding/1.0.10/base64url.ts",
+  "jsr:@std/encoding@^1.0.10/base64url",
+  "jsr:@std/encoding@^1.0.10/base64",
 ]
 `;


### PR DESCRIPTION
## Summary

- Track only direct dependencies, excluding transitive deps from external packages
- Preserve semver ranges from import_map.json (e.g., `jsr:@std/cli@^1.0.25`) instead of fully resolved URLs (e.g., `https://jsr.io/@std/cli/1.0.25/mod.ts`)
- Handle type-only imports by checking both `code` and `type` specifier fields
- Show workspace member aliases (e.g., `@hertzg/binstruct`) instead of file:// paths
- Deduplicate dependencies using Set

## Before

```
[
  "https://jsr.io/@std/cli/1.0.25/_data.json",
  "https://jsr.io/@std/cli/1.0.25/_run_length.ts",
  "https://jsr.io/@std/cli/1.0.25/mod.ts",
  "https://jsr.io/@std/cli/1.0.25/parse_args.ts",
  ...
  "npm:/json5@2.2.3",
]
```

## After

```
[
  "jsr:@std/cli@^1.0.25",
  "@hertzg/binstruct",
  "npm:json5@^2.2.3",
]
```

## Test plan

- [x] All existing tests pass
- [x] Snapshots updated with cleaner format
- [x] Semver patch updates won't break snapshots