### PR TITLE
chore: use consistent semver ranges in import_map.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,18 @@ binary and domain-specific representations.
 - `node:` imports are allowed
 - Import validation enforced by `deno task lint:import-map`
 
+### Updating Dependencies
+
+When updating dependency versions in `import_map.json`, the `deps.test.ts` file
+will fail because it uses snapshots to track dependency versions. This is
+expected behavior, not a breaking change. To fix:
+
+```bash
+deno test --allow-all packages/deps.test.ts -- --update
+```
+
+This updates the snapshots to reflect the new dependency versions.
+
 ### Correct Import Patterns
 
 ```typescript ignore

--- a/import_map.json
+++ b/import_map.json
@@ -2,7 +2,7 @@
   "imports": {
     "@std/assert": "jsr:@std/assert@^1.0.16",
     "@std/bytes": "jsr:@std/bytes@^1.0.6",
-    "@std/cache/memoize": "jsr:@std/cache@0.2.1/memoize",
+    "@std/cache/memoize": "jsr:@std/cache@^0.2.1/memoize",
     "@std/cli": "jsr:@std/cli@^1.0.25",
     "@std/jsonc": "jsr:@std/jsonc@^1.0.2",
     "@std/testing": "jsr:@std/testing@^1.0.16",
@@ -30,7 +30,7 @@
     "@binstruct/png": "jsr:@binstruct/png@^0.3.3",
     "@binstruct/wav": "jsr:@binstruct/wav@^0.1.2",
     "json5": "npm:json5@^2.2.3",
-    "fflate": "npm:fflate@0.8.2",
+    "fflate": "npm:fflate@^0.8.2",
     "@noble/ciphers/aes.js": "jsr:@noble/ciphers@^2.1.1/aes.js",
     "@noble/hashes/legacy.js": "jsr:@noble/hashes@^2.0.1/legacy.js"
   }

--- a/packages/binstruct-png/_deps.snap
+++ b/packages/binstruct-png/_deps.snap
@@ -4,6 +4,6 @@ snapshot[`dependencies > @binstruct/png 1`] = `
 [
   "@hertzg/binstruct",
   "@hertzg/crc",
-  "npm:fflate@0.8.2",
+  "npm:fflate@^0.8.2",
 ]
 `;

--- a/packages/crc/_deps.snap
+++ b/packages/crc/_deps.snap
@@ -2,30 +2,30 @@ export const snapshot = {};
 
 snapshot[`dependencies > @hertzg/crc 1`] = `
 [
-  "jsr:@std/cache@0.2.1/memoize",
+  "jsr:@std/cache@^0.2.1/memoize",
 ]
 `;
 
 snapshot[`dependencies > @hertzg/crc 2`] = `
 [
-  "jsr:@std/cache@0.2.1/memoize",
+  "jsr:@std/cache@^0.2.1/memoize",
 ]
 `;
 
 snapshot[`dependencies > @hertzg/crc 3`] = `
 [
-  "jsr:@std/cache@0.2.1/memoize",
+  "jsr:@std/cache@^0.2.1/memoize",
 ]
 `;
 
 snapshot[`dependencies > @hertzg/crc 4`] = `
 [
-  "jsr:@std/cache@0.2.1/memoize",
+  "jsr:@std/cache@^0.2.1/memoize",
 ]
 `;
 
 snapshot[`dependencies > @hertzg/crc 5`] = `
 [
-  "jsr:@std/cache@0.2.1/memoize",
+  "jsr:@std/cache@^0.2.1/memoize",
 ]
 `;


### PR DESCRIPTION
## Summary

- Change `@std/cache/memoize` from exact `0.2.1` to `^0.2.1`
- Change `fflate` from exact `0.8.2` to `^0.8.2`
- Update dependency snapshots in `deps.test.ts`
- Document `deps.test.ts` snapshot behavior in CLAUDE.md

## Context

The import_map.json had inconsistent version specifications - most packages used `^` semver ranges but two used exact versions. This change makes them consistent.

## Test plan

- [x] `deno task lint` passes
- [x] `deno task test` passes
- [x] Dependency snapshots updated