### PR TITLE
chore: release 2026.01.24

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,5 +1,12 @@
 ### 2026.01.24
 
+#### @hertzg/wg-keys 2.0.0 (major)
+
+- BREAKING(@hertzg/wg-keys): add importPublicKey and rename importPrivateBytes
+  to importPrivateKey (#92)
+
+### 2026.01.24
+
 #### @hertzg/tplink-api 1.1.0 (minor)
 
 - feat(@hertzg/tplink-api): optimize RSA cipher performance (#88)

--- a/import_map.json
+++ b/import_map.json
@@ -22,7 +22,7 @@
     "@hertzg/mymagti-api": "jsr:@hertzg/mymagti-api@^0.1.1",
     "@hertzg/routeros-api": "jsr:@hertzg/routeros-api@^0.1.2",
     "@hertzg/tplink-api": "jsr:@hertzg/tplink-api@^1.1.0",
-    "@hertzg/wg-keys": "jsr:@hertzg/wg-keys@^1.1.0",
+    "@hertzg/wg-keys": "jsr:@hertzg/wg-keys@^2.0.0",
     "@hertzg/wg-ini": "jsr:@hertzg/wg-ini@^0.2.3",
     "@hertzg/wg-conf": "jsr:@hertzg/wg-conf@^0.2.2",
     "@binstruct/cli": "jsr:@binstruct/cli@^0.1.3",

--- a/packages/wg-keys/deno.json
+++ b/packages/wg-keys/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/wg-keys",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "exports": {
     ".": "./mod.ts"
   },


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@hertzg/wg-keys|1.1.0|2.0.0|major|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly







The following commits are ignored:

- [chore: improve dependency snapshot format and tooling (#96)](/hertzg/jsr-monorepo/commit/6d8f5d633151fe415ba5150a00ebf778a841393a)
- [chore: use consistent semver ranges in import_map.json (#94)](/hertzg/jsr-monorepo/commit/a26deb4d73efcd005ceaa4d3c7e86b67afc82530)
- [chore: remove references to non-existent @hertzg/wg-ctl package (#93)](/hertzg/jsr-monorepo/commit/c4247b8e42c02bb5345474166a201edc17d5bb3b)

---

To make edits to this PR:

```sh
git fetch upstream release-2026-01-24-21-01-13 && git checkout -b release-2026-01-24-21-01-13 upstream/release-2026-01-24-21-01-13
```
