### PR TITLE
feat(@hertzg/ip): add isValidIpv4 and isValidIpv6 predicates

### DIFF
--- a/packages/ip/ipv4.ts
+++ b/packages/ip/ipv4.ts
@@ -96,6 +96,47 @@ export function parseIpv4(ip: string): number {
 }
 
 /**
+ * Checks if a string is a valid IPv4 address in dotted decimal notation.
+ *
+ * Returns true if the string can be successfully parsed as an IPv4 address,
+ * false otherwise. This function does not throw exceptions.
+ *
+ * @param ip The string to validate
+ * @returns true if the string is a valid IPv4 address, false otherwise
+ *
+ * @example Valid IPv4 addresses
+ * ```ts
+ * import { assert, assertEquals } from "@std/assert";
+ * import { isValidIpv4 } from "@hertzg/ip/ipv4";
+ *
+ * assert(isValidIpv4("192.168.1.1"));
+ * assert(isValidIpv4("10.0.0.1"));
+ * assert(isValidIpv4("0.0.0.0"));
+ * assert(isValidIpv4("255.255.255.255"));
+ * ```
+ *
+ * @example Invalid IPv4 addresses
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { isValidIpv4 } from "@hertzg/ip/ipv4";
+ *
+ * assertEquals(isValidIpv4("192.168.1"), false);
+ * assertEquals(isValidIpv4("192.168.1.256"), false);
+ * assertEquals(isValidIpv4("192.168.01.1"), false);
+ * assertEquals(isValidIpv4("not an ip"), false);
+ * assertEquals(isValidIpv4(""), false);
+ * ```
+ */
+export function isValidIpv4(ip: string): boolean {
+  try {
+    parseIpv4(ip);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Stringifies a bigint to an IPv4 address in dotted decimal notation.
  *
  * The bigint must represent a valid 32-bit unsigned integer (0 to 4294967295).

--- a/packages/ip/ipv6.ts
+++ b/packages/ip/ipv6.ts
@@ -326,3 +326,53 @@ export function expandIpv6(ip: string): string {
 export function compressIpv6(ip: string): string {
   return stringifyIpv6(parseIpv6(ip));
 }
+
+/**
+ * Checks if a string is a valid IPv6 address.
+ *
+ * Returns true if the string can be successfully parsed as an IPv6 address,
+ * false otherwise. This function does not throw exceptions.
+ *
+ * Supports the same formats as parseIpv6:
+ * - Full form: `2001:0db8:0000:0000:0000:0000:0000:0001`
+ * - Compressed form with `::`: `2001:db8::1`
+ * - Mixed IPv4 form: `::ffff:192.168.1.1`
+ * - Zone IDs: `fe80::1%eth0`
+ *
+ * @param ip The string to validate
+ * @returns true if the string is a valid IPv6 address, false otherwise
+ *
+ * @example Valid IPv6 addresses
+ * ```ts
+ * import { assert } from "@std/assert";
+ * import { isValidIpv6 } from "@hertzg/ip/ipv6";
+ *
+ * assert(isValidIpv6("::"));
+ * assert(isValidIpv6("::1"));
+ * assert(isValidIpv6("2001:db8::1"));
+ * assert(isValidIpv6("fe80::1%eth0"));
+ * assert(isValidIpv6("::ffff:192.168.1.1"));
+ * assert(isValidIpv6("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"));
+ * ```
+ *
+ * @example Invalid IPv6 addresses
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { isValidIpv6 } from "@hertzg/ip/ipv6";
+ *
+ * assertEquals(isValidIpv6("192.168.1.1"), false);
+ * assertEquals(isValidIpv6("2001:db8:::1"), false);
+ * assertEquals(isValidIpv6("2001:db8::1::1"), false);
+ * assertEquals(isValidIpv6("2001:gggg::1"), false);
+ * assertEquals(isValidIpv6("not an ip"), false);
+ * assertEquals(isValidIpv6(""), false);
+ * ```
+ */
+export function isValidIpv6(ip: string): boolean {
+  try {
+    parseIpv6(ip);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/ip/mod.ts
+++ b/packages/ip/mod.ts
@@ -10,6 +10,7 @@
  * ### IPv4
  * - {@link parseIpv4}: Parse dotted decimal notation to number
  * - {@link stringifyIpv4}: Convert number to dotted decimal notation
+ * - {@link isValidIpv4}: Check if string is a valid IPv4 address
  *
  * ### IPv4 CIDR
  * - {@link Cidr4}: Type representing an IPv4 CIDR block
@@ -29,6 +30,7 @@
  * - {@link stringifyIpv6}: Convert bigint to compressed colon-hexadecimal
  * - {@link expandIpv6}: Expand to full uncompressed form
  * - {@link compressIpv6}: Compress to canonical shortest form
+ * - {@link isValidIpv6}: Check if string is a valid IPv6 address
  *
  * ### IPv6 CIDR
  * - {@link Cidr6}: Type representing an IPv6 CIDR block
@@ -261,7 +263,7 @@
  */
 
 // Re-export IPv4 utilities
-export { parseIpv4, stringifyIpv4 } from "./ipv4.ts";
+export { isValidIpv4, parseIpv4, stringifyIpv4 } from "./ipv4.ts";
 
 // Re-export CIDR4 utilities
 export {
@@ -279,7 +281,13 @@ export {
 } from "./cidrv4.ts";
 
 // Re-export IPv6 utilities
-export { compressIpv6, expandIpv6, parseIpv6, stringifyIpv6 } from "./ipv6.ts";
+export {
+  compressIpv6,
+  expandIpv6,
+  isValidIpv6,
+  parseIpv6,
+  stringifyIpv6,
+} from "./ipv6.ts";
 
 // Re-export CIDR6 utilities
 export {


### PR DESCRIPTION
## Summary
- Add `isValidIpv4(ip: string): boolean` validation predicate
- Add `isValidIpv6(ip: string): boolean` validation predicate
- These functions return boolean instead of throwing, useful for input validation

## Test plan
- [x] Unit tests via JSDoc examples
- [x] `deno task lint` passes
- [x] `deno task test` passes