### PR TITLE
feat(@hertzg/ip): add cidr4Size and cidr6Size functions

### DIFF
--- a/packages/ip/cidrv4.ts
+++ b/packages/ip/cidrv4.ts
@@ -261,6 +261,61 @@ export function cidr4BroadcastAddress(cidr: Cidr4): number {
 }
 
 /**
+ * Returns the total number of IP addresses in a CIDR block or for a given prefix length.
+ *
+ * For a /24 network, this returns 256. For a /32, this returns 1.
+ *
+ * @param cidr The CIDR block
+ * @returns The total number of addresses in the CIDR range
+ *
+ * @example Getting CIDR size from Cidr4 object
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { cidr4Size, parseCidr4 } from "@hertzg/ip/cidrv4";
+ *
+ * assertEquals(cidr4Size(parseCidr4("192.168.1.0/24")), 256);
+ * assertEquals(cidr4Size(parseCidr4("10.0.0.0/8")), 16777216);
+ * assertEquals(cidr4Size(parseCidr4("192.168.1.1/32")), 1);
+ * assertEquals(cidr4Size(parseCidr4("0.0.0.0/0")), 4294967296);
+ * ```
+ *
+ * @example Getting CIDR size from prefix length
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { cidr4Size } from "@hertzg/ip/cidrv4";
+ *
+ * assertEquals(cidr4Size(24), 256);
+ * assertEquals(cidr4Size(8), 16777216);
+ * assertEquals(cidr4Size(32), 1);
+ * assertEquals(cidr4Size(0), 4294967296);
+ * ```
+ *
+ * @example Error handling for invalid prefix length
+ * ```ts
+ * import { assertThrows } from "@std/assert";
+ * import { cidr4Size } from "@hertzg/ip/cidrv4";
+ *
+ * assertThrows(() => cidr4Size(-1), RangeError);
+ * assertThrows(() => cidr4Size(33), RangeError);
+ * ```
+ */
+export function cidr4Size(cidr: Cidr4): number;
+export function cidr4Size(prefixLength: number): number;
+export function cidr4Size(cidrOrPrefixLength: Cidr4 | number): number {
+  const prefixLength = typeof cidrOrPrefixLength === "number"
+    ? cidrOrPrefixLength
+    : cidrOrPrefixLength.prefixLength;
+
+  if (prefixLength < 0 || prefixLength > 32 || !Number.isInteger(prefixLength)) {
+    throw new RangeError(
+      `CIDR prefix length must be 0-32, got ${prefixLength}`,
+    );
+  }
+
+  return 2 ** (32 - prefixLength);
+}
+
+/**
  * Generates a range of IP addresses from a CIDR block.
  *
  * Yields IP addresses starting at the specified offset from the

--- a/packages/ip/mod.ts
+++ b/packages/ip/mod.ts
@@ -19,6 +19,7 @@
  * - {@link cidr4Contains}: Check if IP is within CIDR range
  * - {@link cidr4NetworkAddress}: Get network address (first IP)
  * - {@link cidr4BroadcastAddress}: Get broadcast address (last IP)
+ * - {@link cidr4Size}: Get total number of addresses in CIDR range
  * - {@link cidr4Addresses}: Generate IP addresses in CIDR range
  *
  * ### IPv6
@@ -35,6 +36,7 @@
  * - {@link cidr6Contains}: Check if IP is within CIDR range
  * - {@link cidr6NetworkAddress}: Get network address (first IP)
  * - {@link cidr6BroadcastAddress}: Get last address in range
+ * - {@link cidr6Size}: Get total number of addresses in CIDR range
  * - {@link cidr6Addresses}: Generate IP addresses in CIDR range
  *
  * ### Submodules
@@ -266,6 +268,7 @@ export {
   cidr4BroadcastAddress,
   cidr4Contains,
   cidr4NetworkAddress,
+  cidr4Size,
   maskFromPrefixLength,
   parseCidr4,
   stringifyCidr4,
@@ -281,6 +284,7 @@ export {
   cidr6BroadcastAddress,
   cidr6Contains,
   cidr6NetworkAddress,
+  cidr6Size,
   mask6FromPrefixLength,
   parseCidr6,
   stringifyCidr6,


### PR DESCRIPTION
## Summary
- Add `cidr4Size(cidr: Cidr4): number` to get total addresses in IPv4 CIDR block
- Add `cidr6Size(cidr: Cidr6): bigint` to get total addresses in IPv6 CIDR block

## Test plan
- [x] Unit tests via JSDoc examples
- [x] `deno task lint` passes
- [x] `deno task test` passes