### PR TITLE
BREAKING(@hertzg/ip): rename maskFromPrefixLength to mask4FromPrefixLength

### DIFF
--- a/packages/ip/cidrv4.test.ts
+++ b/packages/ip/cidrv4.test.ts
@@ -4,38 +4,38 @@ import {
   cidr4BroadcastAddress,
   cidr4Contains,
   cidr4NetworkAddress,
-  maskFromPrefixLength,
+  mask4FromPrefixLength,
   parseCidr4,
   stringifyCidr4,
 } from "./cidrv4.ts";
 import { parseIpv4, stringifyIpv4 } from "./ipv4.ts";
 
-Deno.test("maskFromPrefixLength", async (t) => {
+Deno.test("mask4FromPrefixLength", async (t) => {
   await t.step("common prefix lengths", () => {
-    assertEquals(maskFromPrefixLength(24), 0xFFFFFF00);
-    assertEquals(maskFromPrefixLength(16), 0xFFFF0000);
-    assertEquals(maskFromPrefixLength(8), 0xFF000000);
+    assertEquals(mask4FromPrefixLength(24), 0xFFFFFF00);
+    assertEquals(mask4FromPrefixLength(16), 0xFFFF0000);
+    assertEquals(mask4FromPrefixLength(8), 0xFF000000);
   });
 
   await t.step("edge cases", () => {
-    assertEquals(maskFromPrefixLength(0), 0);
-    assertEquals(maskFromPrefixLength(32), 0xFFFFFFFF);
+    assertEquals(mask4FromPrefixLength(0), 0);
+    assertEquals(mask4FromPrefixLength(32), 0xFFFFFFFF);
   });
 
   await t.step("various prefix lengths", () => {
-    assertEquals(maskFromPrefixLength(1), 0x80000000);
-    assertEquals(maskFromPrefixLength(30), 0xFFFFFFFC);
-    assertEquals(maskFromPrefixLength(31), 0xFFFFFFFE);
+    assertEquals(mask4FromPrefixLength(1), 0x80000000);
+    assertEquals(mask4FromPrefixLength(30), 0xFFFFFFFC);
+    assertEquals(mask4FromPrefixLength(31), 0xFFFFFFFE);
   });
 
   await t.step("out of range prefix lengths", () => {
     assertThrows(
-      () => maskFromPrefixLength(-1),
+      () => mask4FromPrefixLength(-1),
       RangeError,
       "CIDR prefix length must be 0-32, got -1",
     );
     assertThrows(
-      () => maskFromPrefixLength(33),
+      () => mask4FromPrefixLength(33),
       RangeError,
       "CIDR prefix length must be 0-32, got 33",
     );

--- a/packages/ip/cidrv4.ts
+++ b/packages/ip/cidrv4.ts
@@ -58,25 +58,25 @@ export type Cidr4 = {
  * @example Creating masks
  * ```ts
  * import { assertEquals } from "@std/assert";
- * import { maskFromPrefixLength } from "@hertzg/ip/cidrv4";
+ * import { mask4FromPrefixLength } from "@hertzg/ip/cidrv4";
  *
- * assertEquals(maskFromPrefixLength(24), 0xFFFFFF00);
- * assertEquals(maskFromPrefixLength(16), 0xFFFF0000);
- * assertEquals(maskFromPrefixLength(8), 0xFF000000);
- * assertEquals(maskFromPrefixLength(32), 0xFFFFFFFF);
- * assertEquals(maskFromPrefixLength(0), 0);
+ * assertEquals(mask4FromPrefixLength(24), 0xFFFFFF00);
+ * assertEquals(mask4FromPrefixLength(16), 0xFFFF0000);
+ * assertEquals(mask4FromPrefixLength(8), 0xFF000000);
+ * assertEquals(mask4FromPrefixLength(32), 0xFFFFFFFF);
+ * assertEquals(mask4FromPrefixLength(0), 0);
  * ```
  *
  * @example Error handling
  * ```ts
  * import { assertThrows } from "@std/assert";
- * import { maskFromPrefixLength } from "@hertzg/ip/cidrv4";
+ * import { mask4FromPrefixLength } from "@hertzg/ip/cidrv4";
  *
- * assertThrows(() => maskFromPrefixLength(-1), RangeError);
- * assertThrows(() => maskFromPrefixLength(33), RangeError);
+ * assertThrows(() => mask4FromPrefixLength(-1), RangeError);
+ * assertThrows(() => mask4FromPrefixLength(33), RangeError);
  * ```
  */
-export function maskFromPrefixLength(prefixLength: number): number {
+export function mask4FromPrefixLength(prefixLength: number): number {
   if (
     prefixLength < 0 || prefixLength > 32 || !Number.isInteger(prefixLength)
   ) {
@@ -141,7 +141,7 @@ export function parseCidr4(cidr: string): Cidr4 {
   }
 
   // Validate prefix length
-  maskFromPrefixLength(prefixLength);
+  mask4FromPrefixLength(prefixLength);
 
   return {
     address,
@@ -212,7 +212,7 @@ export function stringifyCidr4(cidr: Cidr4): string {
  * ```
  */
 export function cidr4Contains(cidr: Cidr4, ip: number): boolean {
-  const mask = maskFromPrefixLength(cidr.prefixLength);
+  const mask = mask4FromPrefixLength(cidr.prefixLength);
   const network = (cidr.address & mask) >>> 0;
   return ((ip & mask) >>> 0) === network;
 }
@@ -234,7 +234,7 @@ export function cidr4Contains(cidr: Cidr4, ip: number): boolean {
  * ```
  */
 export function cidr4FirstAddress(cidr: Cidr4): number {
-  const mask = maskFromPrefixLength(cidr.prefixLength);
+  const mask = mask4FromPrefixLength(cidr.prefixLength);
   return (cidr.address & mask) >>> 0;
 }
 
@@ -275,7 +275,7 @@ export const cidr4NetworkAddress = cidr4FirstAddress;
  * ```
  */
 export function cidr4LastAddress(cidr: Cidr4): number {
-  const mask = maskFromPrefixLength(cidr.prefixLength);
+  const mask = mask4FromPrefixLength(cidr.prefixLength);
   const network = (cidr.address & mask) >>> 0;
   return (network | (~mask >>> 0)) >>> 0;
 }

--- a/packages/ip/mod.ts
+++ b/packages/ip/mod.ts
@@ -15,7 +15,7 @@
  * - {@link Cidr4}: Type representing an IPv4 CIDR block
  * - {@link parseCidr4}: Parse CIDR notation string to Cidr4
  * - {@link stringifyCidr4}: Convert Cidr4 to CIDR notation string
- * - {@link maskFromPrefixLength}: Create network mask from prefix length (0-32)
+ * - {@link mask4FromPrefixLength}: Create network mask from prefix length (0-32)
  * - {@link cidr4Contains}: Check if IP is within CIDR range
  * - {@link cidr4FirstAddress}: Get first address in CIDR range
  * - {@link cidr4LastAddress}: Get last address in CIDR range
@@ -273,7 +273,7 @@ export {
   cidr4LastAddress,
   cidr4NetworkAddress,
   cidr4Size,
-  maskFromPrefixLength,
+  mask4FromPrefixLength,
   parseCidr4,
   stringifyCidr4,
 } from "./cidrv4.ts";


### PR DESCRIPTION
## Summary
- Rename `maskFromPrefixLength` to `mask4FromPrefixLength`
- Consistent naming with `mask6FromPrefixLength` for IPv6

## Breaking Change
`maskFromPrefixLength` is removed. Use `mask4FromPrefixLength` instead.

## Test plan
- [x] `deno task lint` passes
- [x] `deno task test` passes