### PR TITLE
BREAKING(@hertzg/ip): rename address functions to firstAddress/lastAddress

### DIFF
--- a/packages/ip/cidrv4.ts
+++ b/packages/ip/cidrv4.ts
@@ -218,7 +218,30 @@ export function cidr4Contains(cidr: Cidr4, ip: number): boolean {
 }
 
 /**
+ * Returns the first address of a CIDR block (network address).
+ *
+ * @param cidr The CIDR block
+ * @returns The first address as a 32-bit unsigned integer
+ *
+ * @example Getting first address
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { cidr4FirstAddress, parseCidr4 } from "@hertzg/ip/cidrv4";
+ * import { parseIpv4 } from "@hertzg/ip/ipv4";
+ *
+ * const cidr = parseCidr4("192.168.1.0/24");
+ * assertEquals(cidr4FirstAddress(cidr), parseIpv4("192.168.1.0"));
+ * ```
+ */
+export function cidr4FirstAddress(cidr: Cidr4): number {
+  const mask = maskFromPrefixLength(cidr.prefixLength);
+  return (cidr.address & mask) >>> 0;
+}
+
+/**
  * Returns the network address (first IP) of a CIDR block.
+ *
+ * Alias for {@link cidr4FirstAddress}.
  *
  * @param cidr The CIDR block
  * @returns The network address as a 32-bit unsigned integer
@@ -233,13 +256,34 @@ export function cidr4Contains(cidr: Cidr4, ip: number): boolean {
  * assertEquals(cidr4NetworkAddress(cidr), parseIpv4("192.168.1.0"));
  * ```
  */
-export function cidr4NetworkAddress(cidr: Cidr4): number {
+export const cidr4NetworkAddress = cidr4FirstAddress;
+
+/**
+ * Returns the last address of a CIDR block (broadcast address for IPv4).
+ *
+ * @param cidr The CIDR block
+ * @returns The last address as a 32-bit unsigned integer
+ *
+ * @example Getting last address
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { cidr4LastAddress, parseCidr4 } from "@hertzg/ip/cidrv4";
+ * import { parseIpv4 } from "@hertzg/ip/ipv4";
+ *
+ * const cidr = parseCidr4("192.168.1.0/24");
+ * assertEquals(cidr4LastAddress(cidr), parseIpv4("192.168.1.255"));
+ * ```
+ */
+export function cidr4LastAddress(cidr: Cidr4): number {
   const mask = maskFromPrefixLength(cidr.prefixLength);
-  return (cidr.address & mask) >>> 0;
+  const network = (cidr.address & mask) >>> 0;
+  return (network | (~mask >>> 0)) >>> 0;
 }
 
 /**
  * Returns the broadcast address (last IP) of a CIDR block.
+ *
+ * Alias for {@link cidr4LastAddress}.
  *
  * @param cidr The CIDR block
  * @returns The broadcast address as a 32-bit unsigned integer
@@ -254,11 +298,7 @@ export function cidr4NetworkAddress(cidr: Cidr4): number {
  * assertEquals(cidr4BroadcastAddress(cidr), parseIpv4("192.168.1.255"));
  * ```
  */
-export function cidr4BroadcastAddress(cidr: Cidr4): number {
-  const mask = maskFromPrefixLength(cidr.prefixLength);
-  const network = (cidr.address & mask) >>> 0;
-  return (network | (~mask >>> 0)) >>> 0;
-}
+export const cidr4BroadcastAddress = cidr4LastAddress;
 
 /**
  * Returns the total number of IP addresses in a CIDR block or for a given prefix length.

--- a/packages/ip/mod.ts
+++ b/packages/ip/mod.ts
@@ -17,8 +17,10 @@
  * - {@link stringifyCidr4}: Convert Cidr4 to CIDR notation string
  * - {@link maskFromPrefixLength}: Create network mask from prefix length (0-32)
  * - {@link cidr4Contains}: Check if IP is within CIDR range
- * - {@link cidr4NetworkAddress}: Get network address (first IP)
- * - {@link cidr4BroadcastAddress}: Get broadcast address (last IP)
+ * - {@link cidr4FirstAddress}: Get first address in CIDR range
+ * - {@link cidr4LastAddress}: Get last address in CIDR range
+ * - {@link cidr4NetworkAddress}: Alias for cidr4FirstAddress
+ * - {@link cidr4BroadcastAddress}: Alias for cidr4LastAddress
  * - {@link cidr4Size}: Get total number of addresses in CIDR range
  * - {@link cidr4Addresses}: Generate IP addresses in CIDR range
  *
@@ -34,8 +36,8 @@
  * - {@link stringifyCidr6}: Convert Cidr6 to CIDR notation string
  * - {@link mask6FromPrefixLength}: Create network mask from prefix length (0-128)
  * - {@link cidr6Contains}: Check if IP is within CIDR range
- * - {@link cidr6NetworkAddress}: Get network address (first IP)
- * - {@link cidr6BroadcastAddress}: Get last address in range
+ * - {@link cidr6FirstAddress}: Get first address in CIDR range
+ * - {@link cidr6LastAddress}: Get last address in CIDR range
  * - {@link cidr6Size}: Get total number of addresses in CIDR range
  * - {@link cidr6Addresses}: Generate IP addresses in CIDR range
  *
@@ -127,8 +129,8 @@
  * ```ts
  * import { assertEquals } from "@std/assert";
  * import {
- *   cidr6BroadcastAddress,
- *   cidr6NetworkAddress,
+ *   cidr6FirstAddress,
+ *   cidr6LastAddress,
  *   parseCidr6,
  *   stringifyCidr6,
  *   stringifyIpv6,
@@ -138,9 +140,9 @@
  * const cidr = parseCidr6("2001:db8::/32");
  * assertEquals(cidr.prefixLength, 32);
  *
- * // Get network boundaries
- * const network = cidr6NetworkAddress(cidr);
- * assertEquals(stringifyIpv6(network), "2001:db8::");
+ * // Get range boundaries
+ * const first = cidr6FirstAddress(cidr);
+ * assertEquals(stringifyIpv6(first), "2001:db8::");
  *
  * // Stringify back to CIDR notation
  * assertEquals(stringifyCidr6(cidr), "2001:db8::/32");
@@ -267,6 +269,8 @@ export {
   cidr4Addresses,
   cidr4BroadcastAddress,
   cidr4Contains,
+  cidr4FirstAddress,
+  cidr4LastAddress,
   cidr4NetworkAddress,
   cidr4Size,
   maskFromPrefixLength,
@@ -281,9 +285,9 @@ export { compressIpv6, expandIpv6, parseIpv6, stringifyIpv6 } from "./ipv6.ts";
 export {
   type Cidr6,
   cidr6Addresses,
-  cidr6BroadcastAddress,
   cidr6Contains,
-  cidr6NetworkAddress,
+  cidr6FirstAddress,
+  cidr6LastAddress,
   cidr6Size,
   mask6FromPrefixLength,
   parseCidr6,


### PR DESCRIPTION
## Summary
- **IPv4**: Add `cidr4FirstAddress` and `cidr4LastAddress` as main implementations
- **IPv4**: Keep `cidr4NetworkAddress` and `cidr4BroadcastAddress` as aliases for backward compatibility
- **IPv6 (BREAKING)**: Rename `cidr6NetworkAddress` to `cidr6FirstAddress`
- **IPv6 (BREAKING)**: Rename `cidr6BroadcastAddress` to `cidr6LastAddress`

The new naming convention uses `firstAddress`/`lastAddress` which is more accurate for IPv6 (which doesn't have traditional broadcast addresses). IPv4 retains aliases for convenience since broadcast/network terminology is standard there.

## Test plan
- [x] Unit tests updated for new function names
- [x] JSDoc examples updated
- [x] `deno task lint` passes
- [x] `deno task test` passes