### PR TITLE
BREAKING(@hertzg/ip): remove bigint from mask6FromPrefixLength signature

### DIFF
--- a/packages/ip/cidrv6.ts
+++ b/packages/ip/cidrv6.ts
@@ -76,22 +76,18 @@ export type Cidr6 = {
  * assertThrows(() => mask6FromPrefixLength(129), RangeError);
  * ```
  */
-export function mask6FromPrefixLength(prefixLength: number | bigint): bigint {
-  const pl = typeof prefixLength === "bigint"
-    ? Number(prefixLength)
-    : prefixLength;
-
-  if (pl < 0 || pl > 128 || !Number.isInteger(pl)) {
+export function mask6FromPrefixLength(prefixLength: number): bigint {
+  if (prefixLength < 0 || prefixLength > 128 || !Number.isInteger(prefixLength)) {
     throw new RangeError(
       `CIDR prefix length must be 0-128, got ${prefixLength}`,
     );
   }
 
-  if (pl === 0) {
+  if (prefixLength === 0) {
     return 0n;
   }
 
-  return (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFn << BigInt(128 - pl)) &
+  return (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFn << BigInt(128 - prefixLength)) &
     0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFn;
 }
 


### PR DESCRIPTION
## Summary
- Change `mask6FromPrefixLength(prefixLength: number | bigint)` to `mask6FromPrefixLength(prefixLength: number)`
- Prefix lengths are small integers (0-128), so bigint support is unnecessary

## Breaking Change
Callers passing bigint values will get a TypeScript error and must convert to number first.

## Test plan
- [x] Unit tests via JSDoc examples
- [x] `deno task lint` passes
- [x] `deno task test` passes