### PR TITLE
BREAKING(@hertzg/ip): change default offset to 0 in cidrAddresses

### DIFF
--- a/packages/ip/cidrv4.test.ts
+++ b/packages/ip/cidrv4.test.ts
@@ -276,13 +276,14 @@ Deno.test("IP assignment workflow", async (t) => {
 });
 
 Deno.test("cidr4Addresses", async (t) => {
-  await t.step("default behavior - iterates full range from offset 1", () => {
+  await t.step("default behavior - iterates full range from offset 0", () => {
     const cidr = parseCidr4("10.0.0.0/29"); // 8 IPs: .0 to .7
 
-    // Default: offset=1, no count limit, step=1
-    const allUsable = Array.from(cidr4Addresses(cidr));
+    // Default: offset=0, no count limit, step=1
+    const all = Array.from(cidr4Addresses(cidr));
 
-    assertEquals(allUsable.map(stringifyIpv4), [
+    assertEquals(all.map(stringifyIpv4), [
+      "10.0.0.0",
       "10.0.0.1",
       "10.0.0.2",
       "10.0.0.3",
@@ -291,16 +292,17 @@ Deno.test("cidr4Addresses", async (t) => {
       "10.0.0.6",
       "10.0.0.7",
     ]);
+    assertEquals(all.length, 8);
   });
 
-  await t.step("iterates full range from offset 0", () => {
+  await t.step("iterates from offset 1 (skip network address)", () => {
     const cidr = parseCidr4("10.0.0.0/29"); // 8 IPs
 
-    const all = Array.from(cidr4Addresses(cidr, { offset: 0 }));
+    const usable = Array.from(cidr4Addresses(cidr, { offset: 1 }));
 
-    assertEquals(all.length, 8);
-    assertEquals(all[0], parseIpv4("10.0.0.0"));
-    assertEquals(all[7], parseIpv4("10.0.0.7"));
+    assertEquals(usable.length, 7);
+    assertEquals(usable[0], parseIpv4("10.0.0.1"));
+    assertEquals(usable[6], parseIpv4("10.0.0.7"));
   });
 
   await t.step("generates addresses from network address", () => {

--- a/packages/ip/cidrv4.ts
+++ b/packages/ip/cidrv4.ts
@@ -368,7 +368,7 @@ export function cidr4Size(cidrOrPrefixLength: Cidr4 | number): number {
  *
  * @param cidr The CIDR block to generate addresses from
  * @param options Optional configuration for address generation
- * @param options.offset The offset from the network address (0-based, defaults to 1 for first usable IP)
+ * @param options.offset The offset from the network address (0-based, defaults to 0 for network address)
  * @param options.count The maximum number of addresses to generate (defaults to undefined = iterate until CIDR boundary)
  * @param options.step The increment between addresses (positive or negative, defaults to 1)
  * @returns A generator yielding IP addresses as 32-bit unsigned integers (may yield less than count if CIDR boundary is reached)
@@ -381,16 +381,17 @@ export function cidr4Size(cidrOrPrefixLength: Cidr4 | number): number {
  *
  * const cidr = parseCidr4("10.0.0.0/29"); // 8 IPs: .0 to .7
  *
- * // By default, iterates from offset 1 (first usable) to CIDR boundary
- * const allUsable = Array.from(cidr4Addresses(cidr));
- * assertEquals(allUsable.map(stringifyIpv4), [
- *   "10.0.0.1", "10.0.0.2", "10.0.0.3",
+ * // By default, iterates from offset 0 (network address) to CIDR boundary
+ * const all = Array.from(cidr4Addresses(cidr));
+ * assertEquals(all.map(stringifyIpv4), [
+ *   "10.0.0.0", "10.0.0.1", "10.0.0.2", "10.0.0.3",
  *   "10.0.0.4", "10.0.0.5", "10.0.0.6", "10.0.0.7",
  * ]);
- *
- * // Iterate from network address through entire range
- * const all = Array.from(cidr4Addresses(cidr, { offset: 0 }));
  * assertEquals(all.length, 8); // All 8 IPs in /29
+ *
+ * // Skip network address by specifying offset 1
+ * const usable = Array.from(cidr4Addresses(cidr, { offset: 1 }));
+ * assertEquals(usable.length, 7); // Skip network address
  * ```
  *
  * @example Limiting with count parameter
@@ -497,7 +498,7 @@ export function* cidr4Addresses(
   },
 ): Generator<number> {
   const network = cidr4NetworkAddress(cidr);
-  const offset = options?.offset ?? 1;
+  const offset = options?.offset ?? 0;
   const count = options?.count;
   const step = options?.step ?? 1;
 

--- a/packages/ip/cidrv6.test.ts
+++ b/packages/ip/cidrv6.test.ts
@@ -284,28 +284,33 @@ Deno.test("IP assignment workflow", async (t) => {
 });
 
 Deno.test("cidr6Addresses", async (t) => {
-  await t.step("default behavior - iterates from offset 1", () => {
+  await t.step("default behavior - iterates from offset 0", () => {
     const cidr = parseCidr6("fd00::/125"); // 8 IPs: ::0 to ::7
 
-    const first5 = Array.from(cidr6Addresses(cidr, { count: 5 }));
+    // Default: offset=0, no count limit, step=1
+    const all = Array.from(cidr6Addresses(cidr));
 
-    assertEquals(first5.map(stringifyIpv6), [
+    assertEquals(all.map(stringifyIpv6), [
+      "fd00::",
       "fd00::1",
       "fd00::2",
       "fd00::3",
       "fd00::4",
       "fd00::5",
+      "fd00::6",
+      "fd00::7",
     ]);
+    assertEquals(all.length, 8);
   });
 
-  await t.step("iterates full range from offset 0", () => {
+  await t.step("iterates from offset 1 (skip network address)", () => {
     const cidr = parseCidr6("fd00::/125"); // 8 IPs
 
-    const all = Array.from(cidr6Addresses(cidr, { offset: 0 }));
+    const usable = Array.from(cidr6Addresses(cidr, { offset: 1 }));
 
-    assertEquals(all.length, 8);
-    assertEquals(all[0], parseIpv6("fd00::0"));
-    assertEquals(all[7], parseIpv6("fd00::7"));
+    assertEquals(usable.length, 7);
+    assertEquals(usable[0], parseIpv6("fd00::1"));
+    assertEquals(usable[6], parseIpv6("fd00::7"));
   });
 
   await t.step("generates addresses from network address", () => {

--- a/packages/ip/cidrv6.ts
+++ b/packages/ip/cidrv6.ts
@@ -342,12 +342,12 @@ export function cidr6Size(cidrOrPrefixLength: Cidr6 | number): bigint {
  *
  * @param cidr The CIDR block to generate addresses from
  * @param options Optional configuration for address generation
- * @param options.offset The offset from the network address (0-based, defaults to 1 for first usable IP)
+ * @param options.offset The offset from the network address (0-based, defaults to 0 for network address)
  * @param options.count The maximum number of addresses to generate (defaults to undefined = iterate until CIDR boundary)
  * @param options.step The increment between addresses (positive or negative, defaults to 1)
  * @returns A generator yielding IP addresses as bigints (may yield less than count if CIDR boundary is reached)
  *
- * @example Default behavior - iterate from offset 1
+ * @example Default behavior - iterate from offset 0
  * ```ts
  * import { assertEquals } from "@std/assert";
  * import { cidr6Addresses, parseCidr6 } from "@hertzg/ip/cidrv6";
@@ -355,10 +355,10 @@ export function cidr6Size(cidrOrPrefixLength: Cidr6 | number): bigint {
  *
  * const cidr = parseCidr6("fd00::/120"); // 256 IPs: ::0 to ::ff
  *
- * // Get first 5 usable IPs (offset=1 by default)
+ * // Get first 5 IPs (offset=0 by default, starts at network address)
  * const first5 = Array.from(cidr6Addresses(cidr, { count: 5 }));
  * assertEquals(first5.map(stringifyIpv6), [
- *   "fd00::1", "fd00::2", "fd00::3", "fd00::4", "fd00::5",
+ *   "fd00::", "fd00::1", "fd00::2", "fd00::3", "fd00::4",
  * ]);
  * ```
  *
@@ -442,7 +442,7 @@ export function* cidr6Addresses(
   },
 ): Generator<bigint> {
   const network = cidr6FirstAddress(cidr);
-  const offset = options?.offset ?? 1;
+  const offset = options?.offset ?? 0;
   const count = options?.count;
   const step = options?.step ?? 1;
 

--- a/packages/ip/mod.ts
+++ b/packages/ip/mod.ts
@@ -176,19 +176,19 @@
  *
  * const cidr = parseCidr4("10.0.0.0/29"); // 8 IPs: .0 to .7
  *
- * // By default, iterates all usable IPs (offset=1, step=1, no count limit)
- * const allUsable = Array.from(cidr4Addresses(cidr));
- * assertEquals(allUsable.map(stringifyIpv4), [
- *   "10.0.0.1", "10.0.0.2", "10.0.0.3",
+ * // By default, iterates all IPs (offset=0, step=1, no count limit)
+ * const all = Array.from(cidr4Addresses(cidr));
+ * assertEquals(all.map(stringifyIpv4), [
+ *   "10.0.0.0", "10.0.0.1", "10.0.0.2", "10.0.0.3",
  *   "10.0.0.4", "10.0.0.5", "10.0.0.6", "10.0.0.7",
  * ]);
  *
- * // Limit with count parameter
- * const first3 = Array.from(cidr4Addresses(cidr, { offset: 0, count: 3 }));
- * assertEquals(first3.length, 3);
+ * // Skip network address with offset=1
+ * const usable = Array.from(cidr4Addresses(cidr, { offset: 1 }));
+ * assertEquals(usable.length, 7);
  *
- * // Get even addresses (step=2, no count = iterate until boundary)
- * const evenIps = Array.from(cidr4Addresses(cidr, { offset: 0, step: 2 }));
+ * // Get even addresses (step=2)
+ * const evenIps = Array.from(cidr4Addresses(cidr, { step: 2 }));
  * assertEquals(evenIps.map(stringifyIpv4), ["10.0.0.0", "10.0.0.2", "10.0.0.4", "10.0.0.6"]);
  *
  * // Reverse iteration from offset (negative step)


### PR DESCRIPTION
## Summary
- Change default offset from 1 to 0 in `cidr4Addresses` and `cidr6Addresses`
- Functions now iterate all addresses by default (including network address)
- Use `offset: 1` to skip the network address if needed

## Breaking Change
Code relying on the default offset of 1 will now include the network address.
To maintain previous behavior, explicitly pass `{ offset: 1 }`.

## Test plan
- [x] Unit tests updated
- [x] JSDoc examples updated
- [x] `deno task lint` passes
- [x] `deno task test` passes