### PR TITLE
chore: add BREAKING type to PR title validation

### DIFF
--- a/.github/workflows/title.yaml
+++ b/.github/workflows/title.yaml
@@ -20,6 +20,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           types: |
+            BREAKING
             build
             chore
             ci


### PR DESCRIPTION
## Summary
- Add `BREAKING` as an allowed commit type in PR title validation
- Enables PRs with breaking changes to use `BREAKING(scope): description` format

## Test plan
- [x] `deno task lint` passes