### PR TITLE
chore: release 2026.01.26

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,17 @@
+### 2026.01.26
+
+#### @hertzg/ip 0.3.0 (minor)
+
+- BREAKING(@hertzg/ip): remove bigint from mask6FromPrefixLength signature
+  (#103)
+- BREAKING(@hertzg/ip): remove bigint from stringifyIpv4 signature (#102)
+- BREAKING(@hertzg/ip): rename maskFromPrefixLength to mask4FromPrefixLength
+  (#100)
+- BREAKING(@hertzg/ip): change default offset to 0 in cidrAddresses (#104)
+- BREAKING(@hertzg/ip): rename address functions to firstAddress/lastAddress
+  (#101)
+- feat(@hertzg/ip): add cidr4Size and cidr6Size functions (#99)
+
 ### 2026.01.24
 
 #### @hertzg/wg-keys 2.0.0 (major)

--- a/import_map.json
+++ b/import_map.json
@@ -17,7 +17,7 @@
     "@std/path": "jsr:@std/path@^1.1.4",
     "@hertzg/binstruct": "jsr:@hertzg/binstruct@^3.0.5",
     "@hertzg/bx": "jsr:@hertzg/bx@^3.0.3",
-    "@hertzg/ip": "jsr:@hertzg/ip@^0.2.1",
+    "@hertzg/ip": "jsr:@hertzg/ip@^0.3.0",
     "@hertzg/crc": "jsr:@hertzg/crc@^0.1.1",
     "@hertzg/mymagti-api": "jsr:@hertzg/mymagti-api@^0.1.1",
     "@hertzg/routeros-api": "jsr:@hertzg/routeros-api@^0.1.2",

--- a/packages/ip/deno.json
+++ b/packages/ip/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@hertzg/ip",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "exports": {
     ".": "./mod.ts",
     "./ipv4": "./ipv4.ts",


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@hertzg/ip|0.2.1|0.3.0|minor|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly







The following commits are ignored:

- [chore: add BREAKING type to PR title validation (#105)](/hertzg/jsr-monorepo/commit/8c2e1f7bfb04b62d7ccaf0dded40cd2198cf5c8f)

---

To make edits to this PR:

```sh
git fetch upstream release-2026-01-26-11-54-36 && git checkout -b release-2026-01-26-11-54-36 upstream/release-2026-01-26-11-54-36
```
