### PR TITLE
feat(@hertzg/ip): document cidrv4Addresses, cidrv6Addresses, Size overloads, and alias return types

### DIFF
--- a/packages/ip/cidrv4.ts
+++ b/packages/ip/cidrv4.ts
@@ -331,13 +331,19 @@ export function cidrv4Size(cidr: Cidrv4): number;
  *
  * @example Getting CIDR size from prefix length
  * ```ts
- * import { assertEquals, assertThrows } from "@std/assert";
+ * import { assertEquals } from "@std/assert";
  * import { cidrv4Size } from "@hertzg/ip/cidrv4";
  *
  * assertEquals(cidrv4Size(24), 256);
  * assertEquals(cidrv4Size(8), 16777216);
  * assertEquals(cidrv4Size(32), 1);
  * assertEquals(cidrv4Size(0), 4294967296);
+ * ```
+ *
+ * @example Out-of-range prefix length throws
+ * ```ts
+ * import { assertThrows } from "@std/assert";
+ * import { cidrv4Size } from "@hertzg/ip/cidrv4";
  *
  * assertThrows(() => cidrv4Size(-1), RangeError);
  * assertThrows(() => cidrv4Size(33), RangeError);
@@ -345,7 +351,7 @@ export function cidrv4Size(cidr: Cidrv4): number;
  */
 export function cidrv4Size(prefixLength: number): number;
 /**
- * Dispatcher overload for callers holding a `Cidrv4 | number`.
+ * Returns the total number of IP addresses for either a CIDR block or a prefix length.
  *
  * @param cidrOrPrefixLength A Cidrv4 block or a prefix length (0-32)
  * @returns The total number of addresses

--- a/packages/ip/cidrv4.ts
+++ b/packages/ip/cidrv4.ts
@@ -452,140 +452,6 @@ export function cidrv4Overlaps(a: Cidrv4, b: Cidrv4): boolean {
 }
 
 /**
- * Generates a range of IP addresses from a CIDR block.
- *
- * Yields IP addresses starting at the specified offset from the
- * network address. The offset is relative to the network address (offset 0 = network address).
- * The step parameter controls the increment (positive or negative) between consecutive addresses.
- * Only addresses within the CIDR range are yielded.
- *
- * By default (when count is not specified), iterates through all addresses in the CIDR range
- * from the offset to the boundary (broadcast for positive step, network for negative step).
- *
- * @param cidr The CIDR block to generate addresses from
- * @param options Optional configuration for address generation
- * @param options.offset The offset from the network address (0-based, defaults to 0 for network address)
- * @param options.count The maximum number of addresses to generate (defaults to undefined = iterate until CIDR boundary)
- * @param options.step The increment between addresses (positive or negative, defaults to 1)
- * @returns A generator yielding IP addresses as 32-bit unsigned integers (may yield less than count if CIDR boundary is reached)
- *
- * @example Default behavior - iterate full CIDR range
- * ```ts
- * import { assertEquals } from "@std/assert";
- * import { cidrv4Addresses, parseCidrv4 } from "@hertzg/ip/cidrv4";
- * import { stringifyIpv4 } from "@hertzg/ip/ipv4";
- *
- * const cidr = parseCidrv4("10.0.0.0/29"); // 8 IPs: .0 to .7
- *
- * // By default, iterates from offset 0 (network address) to CIDR boundary
- * const all = Array.from(cidrv4Addresses(cidr));
- * assertEquals(all.map(stringifyIpv4), [
- *   "10.0.0.0", "10.0.0.1", "10.0.0.2", "10.0.0.3",
- *   "10.0.0.4", "10.0.0.5", "10.0.0.6", "10.0.0.7",
- * ]);
- * assertEquals(all.length, 8); // All 8 IPs in /29
- *
- * // Skip network address by specifying offset 1
- * const usable = Array.from(cidrv4Addresses(cidr, { offset: 1 }));
- * assertEquals(usable.length, 7); // Skip network address
- * ```
- *
- * @example Limiting with count parameter
- * ```ts
- * import { assertEquals } from "@std/assert";
- * import { cidrv4Addresses, parseCidrv4 } from "@hertzg/ip/cidrv4";
- * import { parseIpv4 } from "@hertzg/ip/ipv4";
- *
- * const cidr = parseCidrv4("192.168.1.0/24");
- *
- * // Get first 3 IPs starting at network address
- * const first3 = Array.from(cidrv4Addresses(cidr, { offset: 0, count: 3 }));
- * assertEquals(first3, [
- *   parseIpv4("192.168.1.0"),
- *   parseIpv4("192.168.1.1"),
- *   parseIpv4("192.168.1.2"),
- * ]);
- *
- * // Get 5 IPs starting at offset 10
- * const offset10 = Array.from(cidrv4Addresses(cidr, { offset: 10, count: 5 }));
- * assertEquals(offset10[0], parseIpv4("192.168.1.10"));
- * assertEquals(offset10[4], parseIpv4("192.168.1.14"));
- * ```
- *
- * @example Custom step for even/odd IPs
- * ```ts
- * import { assertEquals } from "@std/assert";
- * import { cidrv4Addresses, parseCidrv4 } from "@hertzg/ip/cidrv4";
- * import { parseIpv4 } from "@hertzg/ip/ipv4";
- *
- * const cidr = parseCidrv4("192.168.1.0/24");
- *
- * // Get every other IP (even addresses)
- * const evenIps = Array.from(cidrv4Addresses(cidr, { offset: 0, count: 5, step: 2 }));
- * assertEquals(evenIps, [
- *   parseIpv4("192.168.1.0"),
- *   parseIpv4("192.168.1.2"),
- *   parseIpv4("192.168.1.4"),
- *   parseIpv4("192.168.1.6"),
- *   parseIpv4("192.168.1.8"),
- * ]);
- *
- * // Get odd addresses
- * const oddIps = Array.from(cidrv4Addresses(cidr, { offset: 1, count: 5, step: 2 }));
- * assertEquals(oddIps[0], parseIpv4("192.168.1.1"));
- * assertEquals(oddIps[1], parseIpv4("192.168.1.3"));
- * ```
- *
- * @example Negative step for reverse iteration
- * ```ts
- * import { assertEquals } from "@std/assert";
- * import { cidrv4Addresses, parseCidrv4 } from "@hertzg/ip/cidrv4";
- * import { parseIpv4 } from "@hertzg/ip/ipv4";
- *
- * const cidr = parseCidrv4("192.168.1.0/24");
- *
- * // Get 5 IPs counting backwards from offset 10
- * const backwards = Array.from(cidrv4Addresses(cidr, { offset: 10, count: 5, step: -1 }));
- * assertEquals(backwards, [
- *   parseIpv4("192.168.1.10"),
- *   parseIpv4("192.168.1.9"),
- *   parseIpv4("192.168.1.8"),
- *   parseIpv4("192.168.1.7"),
- *   parseIpv4("192.168.1.6"),
- * ]);
- * ```
- *
- * @example CIDR boundary handling
- * ```ts
- * import { assert, assertEquals } from "@std/assert";
- * import { cidrv4Addresses, parseCidrv4 } from "@hertzg/ip/cidrv4";
- *
- * const cidr = parseCidrv4("192.168.1.0/29"); // Only 8 IPs: .0 to .7
- *
- * // Requesting more IPs than available stops at CIDR boundary
- * const ips = Array.from(cidrv4Addresses(cidr, { offset: 5, count: 10, step: 1 }));
- * assertEquals(ips.length, 3); // Only .5, .6, .7 are in range
- *
- * // Negative step stops at CIDR start
- * const reverseIps = Array.from(cidrv4Addresses(cidr, { offset: 3, count: 10, step: -1 }));
- * assertEquals(reverseIps.length, 4); // .3, .2, .1, .0
- * ```
- *
- * @example Memory-efficient iteration over large ranges
- * ```ts
- * import { cidrv4Addresses, parseCidrv4 } from "@hertzg/ip/cidrv4";
- * import { stringifyIpv4 } from "@hertzg/ip/ipv4";
- *
- * const cidr = parseCidrv4("10.0.0.0/16"); // 65,536 IPs
- *
- * // Process IPs without loading all into memory
- * for (const ip of cidrv4Addresses(cidr, { offset: 0, count: 65536, step: 1 })) {
- *   const ipStr = stringifyIpv4(ip);
- *   // Process each IP...
- * }
- * ```
- */
-/**
  * Splits an IPv4 CIDR block into its two half-sized children at prefix+1.
  *
  * @param cidr The CIDR block to split
@@ -704,6 +570,126 @@ export function cidrv4Subtract(a: Cidrv4, b: Cidrv4): Cidrv4[] {
   return [...cidrv4Subtract(upper, b), ...cidrv4Subtract(lower, b)];
 }
 
+/**
+ * Generates a range of IP addresses from a CIDR block.
+ *
+ * Yields IP addresses starting at the specified offset from the
+ * network address. The offset is relative to the network address (offset 0 = network address).
+ * The step parameter controls the increment (positive or negative) between consecutive addresses.
+ * Only addresses within the CIDR range are yielded.
+ *
+ * By default (when count is not specified), iterates through all addresses in the CIDR range
+ * from the offset to the boundary (broadcast for positive step, network for negative step).
+ *
+ * @param cidr The CIDR block to generate addresses from
+ * @param options Optional configuration for address generation
+ * @param options.offset The offset from the network address (0-based, defaults to 0 for network address)
+ * @param options.count The maximum number of addresses to generate (defaults to undefined = iterate until CIDR boundary)
+ * @param options.step The increment between addresses (positive or negative, defaults to 1)
+ * @returns A generator yielding IP addresses as 32-bit unsigned integers (may yield less than count if CIDR boundary is reached)
+ *
+ * @example Default behavior - iterate full CIDR range
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { cidrv4Addresses, parseCidrv4 } from "@hertzg/ip/cidrv4";
+ * import { stringifyIpv4 } from "@hertzg/ip/ipv4";
+ *
+ * const cidr = parseCidrv4("10.0.0.0/29"); // 8 IPs: .0 to .7
+ *
+ * // By default, iterates from offset 0 (network address) to CIDR boundary
+ * const all = Array.from(cidrv4Addresses(cidr));
+ * assertEquals(all.map(stringifyIpv4), [
+ *   "10.0.0.0", "10.0.0.1", "10.0.0.2", "10.0.0.3",
+ *   "10.0.0.4", "10.0.0.5", "10.0.0.6", "10.0.0.7",
+ * ]);
+ * assertEquals(all.length, 8); // All 8 IPs in /29
+ *
+ * // Skip network address by specifying offset 1
+ * const usable = Array.from(cidrv4Addresses(cidr, { offset: 1 }));
+ * assertEquals(usable.length, 7); // Skip network address
+ * ```
+ *
+ * @example Limiting with count parameter
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { cidrv4Addresses, parseCidrv4 } from "@hertzg/ip/cidrv4";
+ * import { parseIpv4 } from "@hertzg/ip/ipv4";
+ *
+ * const cidr = parseCidrv4("192.168.1.0/24");
+ *
+ * // Get first 3 IPs starting at network address
+ * const first3 = Array.from(cidrv4Addresses(cidr, { offset: 0, count: 3 }));
+ * assertEquals(first3, [
+ *   parseIpv4("192.168.1.0"),
+ *   parseIpv4("192.168.1.1"),
+ *   parseIpv4("192.168.1.2"),
+ * ]);
+ *
+ * // Get 5 IPs starting at offset 10
+ * const offset10 = Array.from(cidrv4Addresses(cidr, { offset: 10, count: 5 }));
+ * assertEquals(offset10[0], parseIpv4("192.168.1.10"));
+ * assertEquals(offset10[4], parseIpv4("192.168.1.14"));
+ * ```
+ *
+ * @example Custom step for even/odd IPs
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { cidrv4Addresses, parseCidrv4 } from "@hertzg/ip/cidrv4";
+ * import { parseIpv4 } from "@hertzg/ip/ipv4";
+ *
+ * const cidr = parseCidrv4("192.168.1.0/24");
+ *
+ * // Get every other IP (even addresses)
+ * const evenIps = Array.from(cidrv4Addresses(cidr, { offset: 0, count: 5, step: 2 }));
+ * assertEquals(evenIps, [
+ *   parseIpv4("192.168.1.0"),
+ *   parseIpv4("192.168.1.2"),
+ *   parseIpv4("192.168.1.4"),
+ *   parseIpv4("192.168.1.6"),
+ *   parseIpv4("192.168.1.8"),
+ * ]);
+ *
+ * // Get odd addresses
+ * const oddIps = Array.from(cidrv4Addresses(cidr, { offset: 1, count: 5, step: 2 }));
+ * assertEquals(oddIps[0], parseIpv4("192.168.1.1"));
+ * assertEquals(oddIps[1], parseIpv4("192.168.1.3"));
+ * ```
+ *
+ * @example Negative step for reverse iteration
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { cidrv4Addresses, parseCidrv4 } from "@hertzg/ip/cidrv4";
+ * import { parseIpv4 } from "@hertzg/ip/ipv4";
+ *
+ * const cidr = parseCidrv4("192.168.1.0/24");
+ *
+ * // Get 5 IPs counting backwards from offset 10
+ * const backwards = Array.from(cidrv4Addresses(cidr, { offset: 10, count: 5, step: -1 }));
+ * assertEquals(backwards, [
+ *   parseIpv4("192.168.1.10"),
+ *   parseIpv4("192.168.1.9"),
+ *   parseIpv4("192.168.1.8"),
+ *   parseIpv4("192.168.1.7"),
+ *   parseIpv4("192.168.1.6"),
+ * ]);
+ * ```
+ *
+ * @example CIDR boundary handling
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { cidrv4Addresses, parseCidrv4 } from "@hertzg/ip/cidrv4";
+ *
+ * const cidr = parseCidrv4("192.168.1.0/29"); // Only 8 IPs: .0 to .7
+ *
+ * // Requesting more IPs than available stops at CIDR boundary
+ * const ips = Array.from(cidrv4Addresses(cidr, { offset: 5, count: 10, step: 1 }));
+ * assertEquals(ips.length, 3); // Only .5, .6, .7 are in range
+ *
+ * // Negative step stops at CIDR start
+ * const reverseIps = Array.from(cidrv4Addresses(cidr, { offset: 3, count: 10, step: -1 }));
+ * assertEquals(reverseIps.length, 4); // .3, .2, .1, .0
+ * ```
+ */
 export function* cidrv4Addresses(
   cidr: Cidrv4,
   options?: {

--- a/packages/ip/cidrv4.ts
+++ b/packages/ip/cidrv4.ts
@@ -303,7 +303,7 @@ export const cidrv4BroadcastAddress: typeof cidrv4LastAddress =
   cidrv4LastAddress;
 
 /**
- * Returns the total number of IP addresses in a CIDR block or for a given prefix length.
+ * Returns the total number of IP addresses in a CIDR block.
  *
  * For a /24 network, this returns 256. For a /32, this returns 1.
  *
@@ -320,29 +320,36 @@ export const cidrv4BroadcastAddress: typeof cidrv4LastAddress =
  * assertEquals(cidrv4Size(parseCidrv4("192.168.1.1/32")), 1);
  * assertEquals(cidrv4Size(parseCidrv4("0.0.0.0/0")), 4294967296);
  * ```
+ */
+export function cidrv4Size(cidr: Cidrv4): number;
+/**
+ * Returns the total number of IP addresses for a given prefix length.
+ *
+ * @param prefixLength The CIDR prefix length (0-32)
+ * @returns The total number of addresses
+ * @throws {RangeError} If the prefix length is out of range (not 0-32)
  *
  * @example Getting CIDR size from prefix length
  * ```ts
- * import { assertEquals } from "@std/assert";
+ * import { assertEquals, assertThrows } from "@std/assert";
  * import { cidrv4Size } from "@hertzg/ip/cidrv4";
  *
  * assertEquals(cidrv4Size(24), 256);
  * assertEquals(cidrv4Size(8), 16777216);
  * assertEquals(cidrv4Size(32), 1);
  * assertEquals(cidrv4Size(0), 4294967296);
- * ```
- *
- * @example Error handling for invalid prefix length
- * ```ts
- * import { assertThrows } from "@std/assert";
- * import { cidrv4Size } from "@hertzg/ip/cidrv4";
  *
  * assertThrows(() => cidrv4Size(-1), RangeError);
  * assertThrows(() => cidrv4Size(33), RangeError);
  * ```
  */
-export function cidrv4Size(cidr: Cidrv4): number;
 export function cidrv4Size(prefixLength: number): number;
+/**
+ * Dispatcher overload for callers holding a `Cidrv4 | number`.
+ *
+ * @param cidrOrPrefixLength A Cidrv4 block or a prefix length (0-32)
+ * @returns The total number of addresses
+ */
 export function cidrv4Size(cidrOrPrefixLength: Cidrv4 | number): number;
 export function cidrv4Size(cidrOrPrefixLength: Cidrv4 | number): number {
   const prefixLength = typeof cidrOrPrefixLength === "number"

--- a/packages/ip/cidrv4.ts
+++ b/packages/ip/cidrv4.ts
@@ -256,7 +256,8 @@ export function cidrv4FirstAddress(cidr: Cidrv4): number {
  * assertEquals(cidrv4NetworkAddress(cidr), parseIpv4("192.168.1.0"));
  * ```
  */
-export const cidrv4NetworkAddress = cidrv4FirstAddress;
+export const cidrv4NetworkAddress: typeof cidrv4FirstAddress =
+  cidrv4FirstAddress;
 
 /**
  * Returns the last address of a CIDR block (broadcast address for IPv4).
@@ -298,7 +299,8 @@ export function cidrv4LastAddress(cidr: Cidrv4): number {
  * assertEquals(cidrv4BroadcastAddress(cidr), parseIpv4("192.168.1.255"));
  * ```
  */
-export const cidrv4BroadcastAddress = cidrv4LastAddress;
+export const cidrv4BroadcastAddress: typeof cidrv4LastAddress =
+  cidrv4LastAddress;
 
 /**
  * Returns the total number of IP addresses in a CIDR block or for a given prefix length.

--- a/packages/ip/cidrv6.ts
+++ b/packages/ip/cidrv6.ts
@@ -297,12 +297,18 @@ export function cidrv6Size(cidr: Cidrv6): bigint;
  *
  * @example Getting CIDR size from prefix length
  * ```ts
- * import { assertEquals, assertThrows } from "@std/assert";
+ * import { assertEquals } from "@std/assert";
  * import { cidrv6Size } from "@hertzg/ip/cidrv6";
  *
  * assertEquals(cidrv6Size(120), 256n);
  * assertEquals(cidrv6Size(128), 1n);
  * assertEquals(cidrv6Size(64), 18446744073709551616n);
+ * ```
+ *
+ * @example Out-of-range prefix length throws
+ * ```ts
+ * import { assertThrows } from "@std/assert";
+ * import { cidrv6Size } from "@hertzg/ip/cidrv6";
  *
  * assertThrows(() => cidrv6Size(-1), RangeError);
  * assertThrows(() => cidrv6Size(129), RangeError);
@@ -310,7 +316,7 @@ export function cidrv6Size(cidr: Cidrv6): bigint;
  */
 export function cidrv6Size(prefixLength: number): bigint;
 /**
- * Dispatcher overload for callers holding a `Cidrv6 | number`.
+ * Returns the total number of IP addresses for either a CIDR block or a prefix length.
  *
  * @param cidrOrPrefixLength A Cidrv6 block or a prefix length (0-128)
  * @returns The total number of addresses as a bigint

--- a/packages/ip/cidrv6.ts
+++ b/packages/ip/cidrv6.ts
@@ -268,12 +268,10 @@ export function cidrv6LastAddress(cidr: Cidrv6): bigint {
 }
 
 /**
- * Returns the total number of IP addresses in a CIDR block or for a given prefix length.
+ * Returns the total number of IP addresses in a CIDR block.
  *
  * For a /120 network, this returns 256n. For a /128, this returns 1n.
- *
- * **Warning**: IPv6 subnets can be enormous. A /64 has 2^64 addresses.
- * The result is a bigint to handle these large values.
+ * The result is a bigint because IPv6 subnets can hold up to 2^128 addresses.
  *
  * @param cidr The CIDR block
  * @returns The total number of addresses in the CIDR range as a bigint
@@ -288,28 +286,35 @@ export function cidrv6LastAddress(cidr: Cidrv6): bigint {
  * assertEquals(cidrv6Size(parseCidrv6("::1/128")), 1n);
  * assertEquals(cidrv6Size(parseCidrv6("::/64")), 18446744073709551616n);
  * ```
+ */
+export function cidrv6Size(cidr: Cidrv6): bigint;
+/**
+ * Returns the total number of IP addresses for a given prefix length.
+ *
+ * @param prefixLength The CIDR prefix length (0-128)
+ * @returns The total number of addresses as a bigint
+ * @throws {RangeError} If the prefix length is out of range (not 0-128)
  *
  * @example Getting CIDR size from prefix length
  * ```ts
- * import { assertEquals } from "@std/assert";
+ * import { assertEquals, assertThrows } from "@std/assert";
  * import { cidrv6Size } from "@hertzg/ip/cidrv6";
  *
  * assertEquals(cidrv6Size(120), 256n);
  * assertEquals(cidrv6Size(128), 1n);
  * assertEquals(cidrv6Size(64), 18446744073709551616n);
- * ```
- *
- * @example Error handling for invalid prefix length
- * ```ts
- * import { assertThrows } from "@std/assert";
- * import { cidrv6Size } from "@hertzg/ip/cidrv6";
  *
  * assertThrows(() => cidrv6Size(-1), RangeError);
  * assertThrows(() => cidrv6Size(129), RangeError);
  * ```
  */
-export function cidrv6Size(cidr: Cidrv6): bigint;
 export function cidrv6Size(prefixLength: number): bigint;
+/**
+ * Dispatcher overload for callers holding a `Cidrv6 | number`.
+ *
+ * @param cidrOrPrefixLength A Cidrv6 block or a prefix length (0-128)
+ * @returns The total number of addresses as a bigint
+ */
 export function cidrv6Size(cidrOrPrefixLength: Cidrv6 | number): bigint;
 export function cidrv6Size(cidrOrPrefixLength: Cidrv6 | number): bigint {
   const prefixLength = typeof cidrOrPrefixLength === "number"

--- a/packages/ip/cidrv6.ts
+++ b/packages/ip/cidrv6.ts
@@ -420,113 +420,6 @@ export function cidrv6Overlaps(a: Cidrv6, b: Cidrv6): boolean {
 }
 
 /**
- * Generates a range of IP addresses from a CIDR block.
- *
- * Yields IP addresses starting at the specified offset from the
- * network address. The offset is relative to the network address (offset 0 = network address).
- * The step parameter controls the increment (positive or negative) between consecutive addresses.
- * Only addresses within the CIDR range are yielded.
- *
- * By default (when count is not specified), iterates through all addresses in the CIDR range
- * from the offset to the boundary (last address for positive step, network for negative step).
- *
- * **Warning**: IPv6 subnets can be enormous. A /64 has 2^64 addresses. Use count or
- * iterate lazily to avoid memory issues.
- *
- * @param cidr The CIDR block to generate addresses from
- * @param options Optional configuration for address generation
- * @param options.offset The offset from the network address (0-based, defaults to 0 for network address)
- * @param options.count The maximum number of addresses to generate (defaults to undefined = iterate until CIDR boundary)
- * @param options.step The increment between addresses (positive or negative, defaults to 1)
- * @returns A generator yielding IP addresses as bigints (may yield less than count if CIDR boundary is reached)
- *
- * @example Default behavior - iterate from offset 0
- * ```ts
- * import { assertEquals } from "@std/assert";
- * import { cidrv6Addresses, parseCidrv6 } from "@hertzg/ip/cidrv6";
- * import { stringifyIpv6 } from "@hertzg/ip/ipv6";
- *
- * const cidr = parseCidrv6("fd00::/120"); // 256 IPs: ::0 to ::ff
- *
- * // Get first 5 IPs (offset=0 by default, starts at network address)
- * const first5 = Array.from(cidrv6Addresses(cidr, { count: 5 }));
- * assertEquals(first5.map(stringifyIpv6), [
- *   "fd00::", "fd00::1", "fd00::2", "fd00::3", "fd00::4",
- * ]);
- * ```
- *
- * @example Limiting with count parameter
- * ```ts
- * import { assertEquals } from "@std/assert";
- * import { cidrv6Addresses, parseCidrv6 } from "@hertzg/ip/cidrv6";
- * import { parseIpv6 } from "@hertzg/ip/ipv6";
- *
- * const cidr = parseCidrv6("fd00::/120");
- *
- * // Get first 3 IPs starting at network address
- * const first3 = Array.from(cidrv6Addresses(cidr, { offset: 0, count: 3 }));
- * assertEquals(first3, [
- *   parseIpv6("fd00::0"),
- *   parseIpv6("fd00::1"),
- *   parseIpv6("fd00::2"),
- * ]);
- * ```
- *
- * @example Custom step for even IPs
- * ```ts
- * import { assertEquals } from "@std/assert";
- * import { cidrv6Addresses, parseCidrv6 } from "@hertzg/ip/cidrv6";
- * import { parseIpv6 } from "@hertzg/ip/ipv6";
- *
- * const cidr = parseCidrv6("fd00::/120");
- *
- * // Get every other IP (even addresses)
- * const evenIps = Array.from(cidrv6Addresses(cidr, { offset: 0, count: 5, step: 2 }));
- * assertEquals(evenIps, [
- *   parseIpv6("fd00::0"),
- *   parseIpv6("fd00::2"),
- *   parseIpv6("fd00::4"),
- *   parseIpv6("fd00::6"),
- *   parseIpv6("fd00::8"),
- * ]);
- * ```
- *
- * @example Negative step for reverse iteration
- * ```ts
- * import { assertEquals } from "@std/assert";
- * import { cidrv6Addresses, parseCidrv6 } from "@hertzg/ip/cidrv6";
- * import { parseIpv6 } from "@hertzg/ip/ipv6";
- *
- * const cidr = parseCidrv6("fd00::/120");
- *
- * // Get 5 IPs counting backwards from offset 10
- * const backwards = Array.from(cidrv6Addresses(cidr, { offset: 10, count: 5, step: -1 }));
- * assertEquals(backwards, [
- *   parseIpv6("fd00::a"),
- *   parseIpv6("fd00::9"),
- *   parseIpv6("fd00::8"),
- *   parseIpv6("fd00::7"),
- *   parseIpv6("fd00::6"),
- * ]);
- * ```
- *
- * @example CIDR boundary handling
- * ```ts
- * import { assertEquals } from "@std/assert";
- * import { cidrv6Addresses, parseCidrv6 } from "@hertzg/ip/cidrv6";
- *
- * const cidr = parseCidrv6("fd00::/125"); // Only 8 IPs: ::0 to ::7
- *
- * // Requesting more IPs than available stops at CIDR boundary
- * const ips = Array.from(cidrv6Addresses(cidr, { offset: 5, count: 10, step: 1 }));
- * assertEquals(ips.length, 3); // Only ::5, ::6, ::7 are in range
- *
- * // Negative step stops at CIDR start
- * const reverseIps = Array.from(cidrv6Addresses(cidr, { offset: 3, count: 10, step: -1 }));
- * assertEquals(reverseIps.length, 4); // ::3, ::2, ::1, ::0
- * ```
- */
-/**
  * Splits an IPv6 CIDR block into its two half-sized children at prefix+1.
  *
  * @param cidr The CIDR block to split
@@ -641,6 +534,113 @@ export function cidrv6Subtract(a: Cidrv6, b: Cidrv6): Cidrv6[] {
   return [...cidrv6Subtract(upper, b), ...cidrv6Subtract(lower, b)];
 }
 
+/**
+ * Generates a range of IP addresses from a CIDR block.
+ *
+ * Yields IP addresses starting at the specified offset from the
+ * network address. The offset is relative to the network address (offset 0 = network address).
+ * The step parameter controls the increment (positive or negative) between consecutive addresses.
+ * Only addresses within the CIDR range are yielded.
+ *
+ * By default (when count is not specified), iterates through all addresses in the CIDR range
+ * from the offset to the boundary (last address for positive step, network for negative step).
+ *
+ * IPv6 subnets can be enormous. A /64 has 2^64 addresses. Use `count` or iterate lazily
+ * to avoid memory issues.
+ *
+ * @param cidr The CIDR block to generate addresses from
+ * @param options Optional configuration for address generation
+ * @param options.offset The offset from the network address (0-based, defaults to 0 for network address)
+ * @param options.count The maximum number of addresses to generate (defaults to undefined = iterate until CIDR boundary)
+ * @param options.step The increment between addresses (positive or negative, defaults to 1)
+ * @returns A generator yielding IP addresses as bigints (may yield less than count if CIDR boundary is reached)
+ *
+ * @example Default behavior - iterate from offset 0
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { cidrv6Addresses, parseCidrv6 } from "@hertzg/ip/cidrv6";
+ * import { stringifyIpv6 } from "@hertzg/ip/ipv6";
+ *
+ * const cidr = parseCidrv6("fd00::/120"); // 256 IPs: ::0 to ::ff
+ *
+ * // Get first 5 IPs (offset=0 by default, starts at network address)
+ * const first5 = Array.from(cidrv6Addresses(cidr, { count: 5 }));
+ * assertEquals(first5.map(stringifyIpv6), [
+ *   "fd00::", "fd00::1", "fd00::2", "fd00::3", "fd00::4",
+ * ]);
+ * ```
+ *
+ * @example Limiting with count parameter
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { cidrv6Addresses, parseCidrv6 } from "@hertzg/ip/cidrv6";
+ * import { parseIpv6 } from "@hertzg/ip/ipv6";
+ *
+ * const cidr = parseCidrv6("fd00::/120");
+ *
+ * // Get first 3 IPs starting at network address
+ * const first3 = Array.from(cidrv6Addresses(cidr, { offset: 0, count: 3 }));
+ * assertEquals(first3, [
+ *   parseIpv6("fd00::0"),
+ *   parseIpv6("fd00::1"),
+ *   parseIpv6("fd00::2"),
+ * ]);
+ * ```
+ *
+ * @example Custom step for even IPs
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { cidrv6Addresses, parseCidrv6 } from "@hertzg/ip/cidrv6";
+ * import { parseIpv6 } from "@hertzg/ip/ipv6";
+ *
+ * const cidr = parseCidrv6("fd00::/120");
+ *
+ * // Get every other IP (even addresses)
+ * const evenIps = Array.from(cidrv6Addresses(cidr, { offset: 0, count: 5, step: 2 }));
+ * assertEquals(evenIps, [
+ *   parseIpv6("fd00::0"),
+ *   parseIpv6("fd00::2"),
+ *   parseIpv6("fd00::4"),
+ *   parseIpv6("fd00::6"),
+ *   parseIpv6("fd00::8"),
+ * ]);
+ * ```
+ *
+ * @example Negative step for reverse iteration
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { cidrv6Addresses, parseCidrv6 } from "@hertzg/ip/cidrv6";
+ * import { parseIpv6 } from "@hertzg/ip/ipv6";
+ *
+ * const cidr = parseCidrv6("fd00::/120");
+ *
+ * // Get 5 IPs counting backwards from offset 10
+ * const backwards = Array.from(cidrv6Addresses(cidr, { offset: 10, count: 5, step: -1 }));
+ * assertEquals(backwards, [
+ *   parseIpv6("fd00::a"),
+ *   parseIpv6("fd00::9"),
+ *   parseIpv6("fd00::8"),
+ *   parseIpv6("fd00::7"),
+ *   parseIpv6("fd00::6"),
+ * ]);
+ * ```
+ *
+ * @example CIDR boundary handling
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { cidrv6Addresses, parseCidrv6 } from "@hertzg/ip/cidrv6";
+ *
+ * const cidr = parseCidrv6("fd00::/125"); // Only 8 IPs: ::0 to ::7
+ *
+ * // Requesting more IPs than available stops at CIDR boundary
+ * const ips = Array.from(cidrv6Addresses(cidr, { offset: 5, count: 10, step: 1 }));
+ * assertEquals(ips.length, 3); // Only ::5, ::6, ::7 are in range
+ *
+ * // Negative step stops at CIDR start
+ * const reverseIps = Array.from(cidrv6Addresses(cidr, { offset: 3, count: 10, step: -1 }));
+ * assertEquals(reverseIps.length, 4); // ::3, ::2, ::1, ::0
+ * ```
+ */
 export function* cidrv6Addresses(
   cidr: Cidrv6,
   options?: {


### PR DESCRIPTION
- **Orphan fix**: the doc blocks describing `cidrv4Addresses` and `cidrv6Addresses` were attached to nothing during a prior refactor, leaving both generators undocumented on JSR. Each block is moved to its rightful function. One pre-existing example without an assertion is dropped.
- **Alias return types**: `cidrv4NetworkAddress` and `cidrv4BroadcastAddress` are `export const` aliases without explicit type annotations — `deno doc --lint` flags them and JSR shows no signature. Now `: typeof cidrv4FirstAddress` / `cidrv4LastAddress`.
- **Overload JSDoc**: `cidrv4Size` and `cidrv6Size` carried one block on the first overload only; the second and dispatcher overloads were undocumented. Each overload now has its own focused JSDoc.

No behavioral changes.