### PR TITLE
feat(@hertzg/wg-keys): add JSDoc examples for byte/string helpers and split wgPubKey overload docs

### DIFF
--- a/packages/wg-keys/mod.ts
+++ b/packages/wg-keys/mod.ts
@@ -82,6 +82,19 @@ import { decodeBase64, encodeBase64 } from "@std/encoding/base64";
  *
  * @see {@link https://datatracker.ietf.org/doc/html/rfc7748#section-5}
  * @returns {Uint8Array} 32 bytes of random data
+ *
+ * @example Generate 32 random bytes
+ * ```ts
+ * import { assertEquals, assertNotEquals } from "@std/assert";
+ * import { randomBytes } from "@hertzg/wg-keys";
+ *
+ * const a = randomBytes();
+ * const b = randomBytes();
+ *
+ * assertEquals(a.length, 32);
+ * assertEquals(b.length, 32);
+ * assertNotEquals(a, b);
+ * ```
  */
 export function randomBytes(): Uint8Array {
   const randomBytes = new Uint8Array(32);
@@ -98,6 +111,20 @@ export function randomBytes(): Uint8Array {
  *
  * @see {@link https://datatracker.ietf.org/doc/html/rfc7748#section-5}
  * @returns {Uint8Array} private key bytes
+ *
+ * @example Generate clamped private key bytes
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { randomPrivateKeyBytes } from "@hertzg/wg-keys";
+ *
+ * const key = randomPrivateKeyBytes();
+ *
+ * assertEquals(key.length, 32);
+ * // Bits 0, 1, 2 of the first byte are cleared.
+ * assertEquals(key[0] & 0b00000111, 0);
+ * // Bit 7 of the last byte is cleared, bit 6 is set.
+ * assertEquals(key[31] & 0b11000000, 0b01000000);
+ * ```
  */
 export function randomPrivateKeyBytes(): Uint8Array {
   const bytes = randomBytes();
@@ -113,6 +140,14 @@ export function randomPrivateKeyBytes(): Uint8Array {
  *
  * @alias randomBytes
  * @returns {Uint8Array} preshared key bytes
+ *
+ * @example Generate preshared key bytes
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { randomPresharedKeyBytes } from "@hertzg/wg-keys";
+ *
+ * assertEquals(randomPresharedKeyBytes().length, 32);
+ * ```
  */
 export function randomPresharedKeyBytes(): Uint8Array {
   return randomBytes();

--- a/packages/wg-keys/mod.ts
+++ b/packages/wg-keys/mod.ts
@@ -402,6 +402,19 @@ export async function publicBytesFromPrivateBytes(
  *
  * @see {@link https://git.zx2c4.com/wireguard-tools/tree/src/genkey.c}
  * @returns {string} base64 encoded private key
+ *
+ * @example Generate a base64-encoded private key
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { decodeBase64 } from "@std/encoding/base64";
+ * import { wgGenKey } from "@hertzg/wg-keys";
+ *
+ * const key = wgGenKey();
+ *
+ * // 32 bytes encoded as base64 — 44 characters with trailing '='.
+ * assertEquals(key.length, 44);
+ * assertEquals(decodeBase64(key).length, 32);
+ * ```
  */
 export function wgGenKey(): string {
   return encodeBase64(randomPrivateKeyBytes());
@@ -414,31 +427,56 @@ export function wgGenKey(): string {
  *
  * @see {@link https://git.zx2c4.com/wireguard-tools/tree/src/genkey.c}
  * @returns {string} base64 encoded preshared key
+ *
+ * @example Generate a base64-encoded preshared key
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { decodeBase64 } from "@std/encoding/base64";
+ * import { wgGenPsk } from "@hertzg/wg-keys";
+ *
+ * const psk = wgGenPsk();
+ *
+ * assertEquals(psk.length, 44);
+ * assertEquals(decodeBase64(psk).length, 32);
+ * ```
  */
 export function wgGenPsk(): string {
   return encodeBase64(randomPresharedKeyBytes());
 }
 
 /**
- * Derives public key from private key using x25519 curve.
+ * Derives the x25519 public key for a base64-encoded private key.
  *
- * When called with a base64 string, mimics WireGuard's `wg pubkey` command.
- * When called with Uint8Array, works directly with raw bytes.
+ * Mimics WireGuard's `wg pubkey` command — pipe a base64 private key in,
+ * get a base64 public key out.
  *
  * @param privateKeyBase64 Base64 encoded private key
  * @param options Configuration options for key import
- * @returns Base64 encoded public key
+ * @returns Base64 encoded public key (44 characters)
  *
  * @example Derive public key from base64 string
  * ```ts
- * import { assertExists } from "@std/assert";
+ * import { assertEquals } from "@std/assert";
+ * import { decodeBase64 } from "@std/encoding/base64";
  * import { wgGenKey, wgPubKey } from "@hertzg/wg-keys";
  *
  * const privateKey = wgGenKey();
  * const publicKey = await wgPubKey(privateKey);
  *
- * assertExists(publicKey);
+ * assertEquals(publicKey.length, 44);
+ * assertEquals(decodeBase64(publicKey).length, 32);
  * ```
+ */
+export async function wgPubKey(
+  privateKeyBase64: string,
+  options?: ImportPrivateKeyOptions,
+): Promise<string>;
+/**
+ * Derives the x25519 public key for a raw 32-byte private key.
+ *
+ * @param privateKey The 32-byte private key as Uint8Array
+ * @param options Configuration options for key import
+ * @returns The 32-byte public key as Uint8Array
  *
  * @example Derive public key from Uint8Array
  * ```ts
@@ -464,10 +502,6 @@ export function wgGenPsk(): string {
  * assertEquals(publicKeyBytes.length, 32);
  * ```
  */
-export async function wgPubKey(
-  privateKeyBase64: string,
-  options?: ImportPrivateKeyOptions,
-): Promise<string>;
 export async function wgPubKey(
   privateKey: Uint8Array,
   options?: ImportPrivateKeyOptions,


### PR DESCRIPTION
- **Byte helpers**: `randomBytes`, `randomPrivateKeyBytes`, `randomPresharedKeyBytes` now have executable `@example` blocks. The private-key one verifies the X25519 clamping pattern explicitly.
- **String helpers**: `wgGenKey` and `wgGenPsk` get base64 round-trip examples.
- **`wgPubKey` overloads**: each overload now has its own JSDoc and a focused example, matching the `importPrivateKey`/`importPublicKey` pattern used elsewhere in this file. Fixes `deno doc --lint` missing-jsdoc on the `Uint8Array` overload.

No behavioral changes.