### PR TITLE
feat(@hertzg/crc): describe init/xor and the three-layer factory pattern in JSDoc

### DIFF
--- a/packages/crc/crc16.ts
+++ b/packages/crc/crc16.ts
@@ -26,6 +26,8 @@ export const CRC16_IBM_POLYNOMIAL = 0xa001;
 /**
  * Creates a CRC16 function for the given polynomial.
  *
+ * Uses init=0xffff and xor=0xffff (common for CRC16-CCITT and CRC16-IBM).
+ *
  * @param polynomial The CRC16 polynomial to use
  * @returns A function that calculates CRC16 for given data
  *

--- a/packages/crc/crc16.ts
+++ b/packages/crc/crc16.ts
@@ -26,7 +26,9 @@ export const CRC16_IBM_POLYNOMIAL = 0xa001;
 /**
  * Creates a CRC16 function for the given polynomial.
  *
- * Uses init=0xffff and xor=0xffff (common for CRC16-CCITT and CRC16-IBM).
+ * Uses init=0xffff and xor=0xffff. With `CRC16_CCITT_POLYNOMIAL` this matches
+ * CRC-16/X-25; other catalogue variants (CRC-16/ARC, CRC-16/MODBUS) use
+ * different init/xor and need a custom implementation.
  *
  * @param polynomial The CRC16 polynomial to use
  * @returns A function that calculates CRC16 for given data

--- a/packages/crc/crc32.ts
+++ b/packages/crc/crc32.ts
@@ -23,11 +23,13 @@ export const CRC32_POLYNOMIAL = 0xedb88320;
 /** CRC32C polynomial (iSCSI, SCTP, ext4). Also known as Castagnoli. */
 export const CRC32C_POLYNOMIAL = 0x82f63b78;
 
-/** CRC32K polynomial (Koopman). */
+/** CRC32K polynomial (Koopman). Better Hamming-distance properties than CRC32 on short messages. */
 export const CRC32K_POLYNOMIAL = 0xeb31d82e;
 
 /**
  * Creates a CRC32 function for the given polynomial.
+ *
+ * Uses init=0xffffffff and xor=0xffffffff (common for CRC32, CRC32C, and CRC32K).
  *
  * @param polynomial The CRC32 polynomial to use
  * @returns A function that calculates CRC32 for given data

--- a/packages/crc/crc32.ts
+++ b/packages/crc/crc32.ts
@@ -23,7 +23,7 @@ export const CRC32_POLYNOMIAL = 0xedb88320;
 /** CRC32C polynomial (iSCSI, SCTP, ext4). Also known as Castagnoli. */
 export const CRC32C_POLYNOMIAL = 0x82f63b78;
 
-/** CRC32K polynomial (Koopman). Better Hamming-distance properties than CRC32 on short messages. */
+/** CRC32K polynomial (Koopman). Designed for improved Hamming-distance coverage. */
 export const CRC32K_POLYNOMIAL = 0xeb31d82e;
 
 /**

--- a/packages/crc/crc64.ts
+++ b/packages/crc/crc64.ts
@@ -30,8 +30,10 @@ const CRC64_MASK = 0xffffffffffffffffn;
 /**
  * Creates a CRC64 function for the given polynomial.
  *
- * Uses init=0xffffffffffffffff and xor=0xffffffffffffffff (common for CRC64-ECMA
- * and CRC64-ISO). BigInt is used for 64-bit precision.
+ * Uses init=0xffffffffffffffff and xor=0xffffffffffffffff. With
+ * `CRC64_ECMA_POLYNOMIAL` this matches CRC-64/XZ; other catalogue variants
+ * (notably CRC-64/ECMA-182 proper, which uses init=0/xor=0) need different
+ * init/xor. BigInt is used for 64-bit precision.
  *
  * @param polynomial The CRC64 polynomial to use (must be BigInt)
  * @returns A function that calculates CRC64 for given data

--- a/packages/crc/crc64.ts
+++ b/packages/crc/crc64.ts
@@ -30,7 +30,8 @@ const CRC64_MASK = 0xffffffffffffffffn;
 /**
  * Creates a CRC64 function for the given polynomial.
  *
- * Uses BigInt for 64-bit precision. The polynomial must be a BigInt.
+ * Uses init=0xffffffffffffffff and xor=0xffffffffffffffff (common for CRC64-ECMA
+ * and CRC64-ISO). BigInt is used for 64-bit precision.
  *
  * @param polynomial The CRC64 polynomial to use (must be BigInt)
  * @returns A function that calculates CRC64 for given data

--- a/packages/crc/mod.ts
+++ b/packages/crc/mod.ts
@@ -2,10 +2,16 @@
  * CRC implementation with configurable polynomials.
  *
  * A pure TypeScript CRC library supporting CRC8, CRC16, CRC32, and CRC64.
- * Use the simple `crc*` helpers with default polynomials, or the `createCrc*`
- * factory functions for custom polynomials.
  *
- * @example Simple usage with default polynomials
+ * Each width is exposed at three layers:
+ * - One-shot: `crc8` / `crc16` / `crc32` / `crc64` — convenience helpers that
+ *   use a conventional default polynomial.
+ * - Factory: `createCrc8` / etc. — return a reusable function bound to a
+ *   specific polynomial (each call builds the lookup table).
+ * - Memoized factory: `memoizedCreateCrc8` / etc. — same as the factory, but
+ *   repeated calls with the same polynomial reuse the cached function.
+ *
+ * @example One-shot helpers with default polynomials
  * ```ts
  * import { assertEquals } from "@std/assert";
  * import { crc32, crc64 } from "@hertzg/crc";
@@ -14,7 +20,7 @@
  * assertEquals(crc64(new TextEncoder().encode("123456789")), 0x995dc9bbdf1939fan);
  * ```
  *
- * @example Custom polynomial with factory function
+ * @example Factory with a custom polynomial (CRC32C / Castagnoli)
  * ```ts
  * import { assertEquals } from "@std/assert";
  * import { createCrc32, CRC32C_POLYNOMIAL } from "@hertzg/crc";


### PR DESCRIPTION
- **Three-layer @module description**: `mod.ts` now spells out the one-shot / factory / memoized-factory layers explicitly, so a reader landing on the package page can pick the right entry point without reading the source.
- **init/xor parity**: `createCrc16`, `createCrc32`, `createCrc64` now document their init and xor values, matching what `createCrc8` already does. The factory layer is the pluggable seam, so init/xor belong in JSDoc next to the polynomial.
- **CRC32K (Koopman)**: expand the bare "(Koopman)" tag with the property that motivates choosing it.

No behavioral changes.