### PR TITLE
feat(@binstruct/cli): correct stale jsonc references and tighten command/loader JSDoc

### DIFF
--- a/packages/binstruct-cli/cli.ts
+++ b/packages/binstruct-cli/cli.ts
@@ -42,18 +42,12 @@ export interface CliOptions {
 /**
  * Parses command line arguments and returns configuration.
  *
+ * Accepts both the flag-based form (`-p <pkg> -c <coder> <command>`) and
+ * the positional form (`<pkg> <coder> <command>`); positional wins only
+ * when neither flag is set and there are at least three arguments.
+ *
  * @param args Command line arguments
  * @returns Parsed CLI options
- *
- * @example
- * ```ts
- * import { assertEquals } from "@std/assert";
- * import { main } from "./cli.ts";
- *
- * // The parseCliArgs function is used internally by main
- * const result = main(["--help"]);
- * assertEquals(result instanceof Promise, true);
- * ```
  */
 function parseCliArgs(args: string[]): CliOptions {
   const parsed = parseArgs(args, {
@@ -145,16 +139,12 @@ function showVersion(): void {
 /**
  * Main CLI entry point.
  *
- * @param args Command line arguments (defaults to Deno.args)
+ * Parses arguments, dispatches to `decode` or `encode`, and exits the
+ * process with status 1 on argument or runtime errors. When invoked
+ * with `--help` or `--version`, writes the requested information to
+ * stdout and returns.
  *
- * @example
- * ```ts
- * import { main } from "./cli.ts";
- *
- * // Called automatically when run as script
- * // Show help information
- * await main(["--help"]);
- * ```
+ * @param args Command line arguments (defaults to `Deno.args`)
  */
 export async function main(args: string[] = Deno.args): Promise<void> {
   const options = parseCliArgs(args);

--- a/packages/binstruct-cli/commands/decode.ts
+++ b/packages/binstruct-cli/commands/decode.ts
@@ -20,16 +20,6 @@ import { readStdin, writeStdoutFormatted } from "../io.ts";
  * @param packageSpec Package specifier (JSR URL, local path, or npm package)
  * @param coderName Name of the coder to use from the package
  * @param format Output format: "jsonc" (default)
- *
- * @example
- * ```ts
- * import { assertEquals } from "@std/assert";
- * import { decodeCommand } from "./decode.ts";
- *
- * // This would be called from the CLI with stdin input
- * // const result = decodeCommand("jsr:@binstruct/png", "pngFile", "jsonc");
- * // assertEquals(result instanceof Promise, true);
- * ```
  */
 export async function decodeCommand(
   packageSpec: string,

--- a/packages/binstruct-cli/commands/encode.ts
+++ b/packages/binstruct-cli/commands/encode.ts
@@ -20,16 +20,6 @@ import { readStdinFormatted, writeStdout } from "../io.ts";
  * @param packageSpec Package specifier (JSR URL, local path, or npm package)
  * @param coderName Name of the coder to use from the package
  * @param format Input format: "jsonc" (default)
- *
- * @example
- * ```ts
- * import { assertEquals } from "@std/assert";
- * import { encodeCommand } from "./encode.ts";
- *
- * // This would be called from the CLI with stdin input
- * // const result = encodeCommand("jsr:@binstruct/png", "pngFile", "jsonc");
- * // assertEquals(result instanceof Promise, true);
- * ```
  */
 export async function encodeCommand(
   packageSpec: string,

--- a/packages/binstruct-cli/io.ts
+++ b/packages/binstruct-cli/io.ts
@@ -3,8 +3,8 @@
  *
  * This module provides shared utilities for reading from stdin and writing to stdout,
  * used by both encode and decode commands. It includes support for serializing and
- * deserializing non-native types like Uint8Array and BigInt, and supports JSONC
- * format through @std/jsonc.
+ * deserializing non-native types like Uint8Array and BigInt, and accepts JSON5
+ * (JSON with comments and trailing commas) on input.
  *
  * @module
  */
@@ -44,12 +44,12 @@ export async function readStdin(): Promise<Uint8Array> {
 }
 
 /**
- * Reads JSON or JSONC data from stdin and parses it with support for non-native types.
+ * Reads JSON or JSON5 data from stdin and parses it with support for non-native types.
  *
- * This function can reconstruct Uint8Array and BigInt values from their
- * JSON-serialized representations. Supports JSONC (JSON with comments) format.
+ * Reconstructs Uint8Array and BigInt values from their JSON-serialized
+ * representations. Comments and trailing commas are accepted.
  *
- * @returns Parsed JSON/JSONC data with non-native types reconstructed
+ * @returns Parsed data with non-native types reconstructed
  */
 export async function readStdinJson(): Promise<unknown> {
   const binaryData = await readStdin();
@@ -69,10 +69,11 @@ export async function readStdinJson(): Promise<unknown> {
 }
 
 /**
- * Reads JSONC data from stdin and parses it with support for non-native types.
+ * Reads formatted data from stdin and parses it with support for non-native types.
  *
- * This function can reconstruct Uint8Array and BigInt values from their
- * JSON-serialized representations. Supports JSONC (JSON with comments) format.
+ * Currently the only supported format is `"jsonc"`, which parses JSON5
+ * (JSON with comments and trailing commas) and reconstructs Uint8Array and
+ * BigInt values.
  *
  * @param format The format to parse: "jsonc" (default)
  * @returns Parsed data with non-native types reconstructed
@@ -124,10 +125,11 @@ export async function writeStdoutJson(data: unknown): Promise<void> {
 }
 
 /**
- * Writes JSONC data to stdout with support for non-native types.
+ * Writes formatted data to stdout with support for non-native types.
  *
- * This function handles Uint8Array and BigInt values by converting them to
- * JSON-serializable formats that can be reconstructed later.
+ * Currently the only supported format is `"jsonc"`, which produces JSON5
+ * with hex-formatted byte arrays. Uint8Array and BigInt values are
+ * converted to a form that can be round-tripped back via {@link readStdinFormatted}.
  *
  * @param data Data to serialize and write
  * @param format The format to use: "jsonc" (default)

--- a/packages/binstruct-cli/loader.ts
+++ b/packages/binstruct-cli/loader.ts
@@ -12,31 +12,16 @@ import type { Coder } from "@hertzg/binstruct";
 /**
  * Loads a coder from the specified package.
  *
- * @param packageSpec Package specifier (JSR URL, local path, or npm package)
- * @param coderName Name of the coder to use from the package
- * @returns The loaded coder function
+ * `packageSpec` is forwarded to dynamic `import()`, so any specifier the
+ * runtime accepts works — `jsr:@scope/pkg`, `npm:pkg`, an absolute URL,
+ * or a local path. The package must export `coderName` as a function
+ * returning a coder (an object with `encode` and `decode`).
  *
- * @example Loading a coder from a JSR package
- * ```ts
- * import { assertEquals } from "@std/assert";
- * import { loadCoder } from "./loader.ts";
+ * @param packageSpec Package specifier (JSR URL, npm package, or local path)
+ * @param coderName Name of the coder factory to import
+ * @returns The coder instance
  *
- * const coder = await loadCoder("jsr:@binstruct/png", "pngFile");
- * assertEquals(typeof coder.decode, "function");
- * assertEquals(typeof coder.encode, "function");
- * ```
- *
- * @example Loading a coder from a local package
- * ```ts
- * import { assertEquals } from "@std/assert";
- * import { loadCoder } from "./loader.ts";
- *
- * const coder = await loadCoder("../binstruct-png/mod.ts", "pngFile");
- * assertEquals(typeof coder.decode, "function");
- * assertEquals(typeof coder.encode, "function");
- * ```
- *
- * @example Loading a coder from an npm package
+ * @example Load a coder from a JSR package
  * ```ts
  * import { assertEquals } from "@std/assert";
  * import { loadCoder } from "./loader.ts";

--- a/packages/binstruct-cli/mod.ts
+++ b/packages/binstruct-cli/mod.ts
@@ -7,7 +7,8 @@
  *
  * The CLI supports both decoding binary data from stdin to JSON on stdout
  * and encoding JSON data from stdin to binary on stdout, making it easy to
- * integrate with shell pipelines and other tools. JSONC is the default format.
+ * integrate with shell pipelines and other tools. JSON5 (JSON with comments
+ * and trailing commas) is the default on-the-wire format.
  *
  * @example Basic decode usage (with flags) - JSON output
  * ```bash

--- a/packages/binstruct-cli/serialization.ts
+++ b/packages/binstruct-cli/serialization.ts
@@ -3,11 +3,11 @@
  *
  * This module provides utilities for serializing and deserializing non-native
  * types like Uint8Array and BigInt that are commonly used in binary structures.
- * This ensures that data decoded from binary can be properly serialized to JSONC
- * and then reconstructed when encoding back to binary.
+ * Data decoded from binary is serialized to JSON5 (JSON with comments and
+ * trailing commas) and reconstructed when encoding back to binary.
  *
- * Uses @std/jsonc for JSONC parsing with custom logic for handling non-native
- * types during serialization.
+ * Uses `json5` for parsing with custom logic for handling non-native types
+ * during serialization.
  *
  * @module
  */
@@ -49,11 +49,11 @@ export function serializeToJson(value: unknown): string {
 /**
  * Deserializes JSON with support for non-native types.
  *
- * This function reconstructs Uint8Array and BigInt values from their
- * JSON-serialized representations. Uses @std/jsonc to support JSONC
- * (JSON with comments) format.
+ * Reconstructs Uint8Array and BigInt values from their JSON-serialized
+ * representations. Parses with `json5`, so comments and trailing commas
+ * are accepted.
  *
- * @param json The JSON or JSONC string to deserialize
+ * @param json The JSON or JSON5 string to deserialize
  * @returns Deserialized value with non-native types reconstructed
  *
  * @example
@@ -70,7 +70,7 @@ export function serializeToJson(value: unknown): string {
  * ```
  */
 export function deserializeFromJson(json: string): unknown {
-  // Use @std/jsonc to parse JSONC (JSON with comments)
+  // Parse with json5 (JSON with comments and trailing commas).
   const parsed = JSON5.parse(json);
 
   // Apply custom reviver for non-native types


### PR DESCRIPTION
- **Stale parser reference**: \`io.ts\` and \`serialization.ts\` described the parser as \`@std/jsonc\`, but the implementation has been \`json5\` the whole time. Aligns the JSDoc with what the code actually does.
- **Drop fake/empty examples**: \`decodeCommand\`, \`encodeCommand\`, and \`main\` are stdin/stdout-bound shells; their \`@example\` blocks were either commented-out non-code or asserted nothing meaningful. Replaced with prose describing the actual contract. The stray \`@example\` on the private \`parseCliArgs\` (which pointed at \`main\`) is gone.
- **Loader examples**: three near-identical \`loadCoder\` examples (jsr/local/npm) collapsed to one canonical block; the supported specifier forms are now described in prose.

No behavioral changes.