### PR TITLE
feat(@binstruct/ethernet)!: mark MAC extraction as breaking (Release-As 1.0.0)

### DIFF
--- a/packages/binstruct-ethernet/mod.ts
+++ b/packages/binstruct-ethernet/mod.ts
@@ -4,6 +4,18 @@
  * For MAC address parsing/stringification, use the sister package
  * {@link https://jsr.io/@hertzg/mac @hertzg/mac}.
  *
+ * ## Migration from 0.x
+ *
+ * The `parseMacAddress` and `stringifyMacAddress` exports were removed in
+ * 1.0. Replace with `@hertzg/mac`:
+ *
+ * ```ts ignore
+ * // before
+ * import { parseMacAddress, stringifyMacAddress } from "@binstruct/ethernet";
+ * // after
+ * import { parse as parseMac, stringify as stringifyMac } from "@hertzg/mac";
+ * ```
+ *
  * @example Basic encoding and decoding
  * ```ts
  * import { assertEquals } from "@std/assert";


### PR DESCRIPTION
The MAC extraction (#167) removed \`parseMacAddress\` and \`stringifyMacAddress\` from \`@binstruct/ethernet\`'s public surface but landed as a non-breaking \`feat\`. Removing public exports is a breaking change. This PR retroactively flags it via Conventional Commits + a \`Release-As: 1.0.0\` footer so release-please regenerates #166 with \`@binstruct/ethernet\` at 1.0.0.

Also adds a "Migration from 0.x" block to the \`@module\` JSDoc so the removal is obvious on the JSR landing page.

Merge before #166 to get the correct version on the next publish.