### PR TITLE
feat(@hertzg/binstruct): add refineFields for per-field bytes refinement

### DIFF
--- a/packages/@hertzg/binstruct/mod.ts
+++ b/packages/@hertzg/binstruct/mod.ts
@@ -414,5 +414,10 @@ export { bytes } from "./bytes/bytes.ts";
 export { type BitSchema, bitStruct } from "./bits/bit-struct.ts";
 export { refine, type Refiner } from "./refine/refine.ts";
 export { type RefinedUnion, refineSwitch } from "./refine/switch.ts";
+export {
+  type DecodedFields,
+  type FieldCoders,
+  refineFields,
+} from "./refine/fields.ts";
 export { decode, encode } from "./helpers.ts";
 export { autoGrowBuffer, type AutogrowOptions } from "./buffer.ts";

--- a/packages/@hertzg/binstruct/refine/fields.test.ts
+++ b/packages/@hertzg/binstruct/refine/fields.test.ts
@@ -1,0 +1,116 @@
+import { assertEquals } from "@std/assert";
+import { bytes } from "../bytes/bytes.ts";
+import { u16be, u8 } from "../numeric/numeric.ts";
+import { string } from "../string/string.ts";
+import { struct } from "../struct/struct.ts";
+import { refine } from "./refine.ts";
+import { refineSwitch } from "./switch.ts";
+import { refineFields } from "./fields.ts";
+
+Deno.test("refineFields: refines a single payload field", () => {
+  const inner = struct({ a: u8(), b: u8() });
+  const outer = struct({ tag: u16be(), payload: bytes(2) });
+
+  const coder = refine(outer, refineFields({ payload: inner }))();
+  const buffer = new Uint8Array(4);
+  const written = coder.encode(
+    { tag: 0xbeef, payload: { a: 1, b: 2 } },
+    buffer,
+  );
+  const [decoded, read] = coder.decode(buffer);
+
+  assertEquals(written, 4);
+  assertEquals(read, 4);
+  assertEquals(decoded.tag, 0xbeef);
+  assertEquals(decoded.payload.a, 1);
+  assertEquals(decoded.payload.b, 2);
+});
+
+Deno.test("refineFields: refines multiple fields in one pass", () => {
+  const word = struct({ value: u16be() });
+  const host = struct({ a: bytes(2), b: bytes(2) });
+
+  const coder = refine(host, refineFields({ a: word, b: word }))();
+  const buffer = new Uint8Array(4);
+  const written = coder.encode(
+    { a: { value: 0x1234 }, b: { value: 0x5678 } },
+    buffer,
+  );
+  const [decoded, read] = coder.decode(buffer);
+
+  assertEquals(written, 4);
+  assertEquals(read, 4);
+  assertEquals(decoded.a.value, 0x1234);
+  assertEquals(decoded.b.value, 0x5678);
+});
+
+Deno.test("refineFields: unlisted fields pass through unchanged", () => {
+  const inner = struct({ value: u8() });
+  const host = struct({
+    keepMe: u16be(),
+    refined: bytes(1),
+    alsoKeepMe: u8(),
+  });
+
+  const coder = refine(host, refineFields({ refined: inner }))();
+  const buffer = new Uint8Array(4);
+  const written = coder.encode(
+    { keepMe: 0xcafe, refined: { value: 7 }, alsoKeepMe: 0x42 },
+    buffer,
+  );
+  const [decoded, read] = coder.decode(buffer);
+
+  assertEquals(written, 4);
+  assertEquals(read, 4);
+  assertEquals(decoded.keepMe, 0xcafe);
+  assertEquals(decoded.refined.value, 7);
+  assertEquals(decoded.alsoKeepMe, 0x42);
+});
+
+Deno.test("refineFields: composes as a refineSwitch arm", () => {
+  type Tag = 1 | 2;
+  const word = struct({ value: u16be() });
+  const text = struct({ value: string() });
+  const base = struct({ tag: u8(), payload: bytes(2) });
+
+  const coder = refineSwitch(
+    base,
+    {
+      word: refineFields({ payload: word }),
+      text: refineFields({ payload: text }),
+    },
+    {
+      refine: (host) => (host.tag === 1 ? "word" : "text"),
+      unrefine: (host) => (host.tag === 1 ? "word" : "text"),
+    },
+  );
+
+  const buffer = new Uint8Array(8);
+
+  // Encode a word-payload entry.
+  const wordValue = {
+    tag: 1 as Tag,
+    payload: { value: 0xabcd },
+  } as const;
+  const written = coder.encode(wordValue, buffer);
+  const [decoded] = coder.decode(buffer.subarray(0, written));
+
+  assertEquals(decoded.tag, 1);
+  assertEquals("value" in decoded.payload, true);
+  if ("value" in decoded.payload && typeof decoded.payload.value === "number") {
+    assertEquals(decoded.payload.value, 0xabcd);
+  }
+});
+
+Deno.test("refineFields: round-trips an empty coder map (identity)", () => {
+  const host = struct({ a: u8(), b: u8() });
+
+  const coder = refine(host, refineFields({}))();
+  const buffer = new Uint8Array(2);
+  const written = coder.encode({ a: 1, b: 2 }, buffer);
+  const [decoded, read] = coder.decode(buffer);
+
+  assertEquals(written, 2);
+  assertEquals(read, 2);
+  assertEquals(decoded, { a: 1, b: 2 });
+});

--- a/packages/@hertzg/binstruct/refine/fields.ts
+++ b/packages/@hertzg/binstruct/refine/fields.ts
@@ -1,0 +1,143 @@
+/**
+ * Builds a {@linkcode Refiner} that swaps one or more `Uint8Array` fields of
+ * a host record for typed values produced by per-field sub-coders.
+ *
+ * Useful for layered binary formats where a host record carries a payload
+ * (or several) as raw bytes that should be interpreted via a nested coder.
+ * Common case: an Ethernet frame's `payload` field holds an IPv4 datagram,
+ * an ICMP packet, or another layer's wire bytes — `refineFields` lets you
+ * surface the typed value in place without rewriting the host coder.
+ *
+ * Each entry in the `coders` map names a host field whose value is a
+ * `Uint8Array` and the coder used to decode/encode that field's bytes.
+ * Fields not listed are forwarded unchanged.
+ *
+ * @example Refine a single field
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { bytes, refine, refineFields, struct, u16be, u8 } from "@hertzg/binstruct";
+ *
+ * const inner = struct({ a: u8(), b: u8() });
+ * const outer = struct({ tag: u16be(), payload: bytes(2) });
+ *
+ * const coder = refine(outer, refineFields({ payload: inner }))();
+ * const buffer = new Uint8Array(4);
+ *
+ * coder.encode({ tag: 0xbeef, payload: { a: 1, b: 2 } }, buffer);
+ * const [decoded] = coder.decode(buffer);
+ *
+ * assertEquals(decoded, { tag: 0xbeef, payload: { a: 1, b: 2 } });
+ * ```
+ *
+ * @example Refine multiple fields in one pass
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { bytes, refine, refineFields, struct, u16be } from "@hertzg/binstruct";
+ *
+ * const word = struct({ value: u16be() });
+ * const host = struct({ a: bytes(2), b: bytes(2) });
+ *
+ * const coder = refine(host, refineFields({ a: word, b: word }))();
+ * const buffer = new Uint8Array(4);
+ *
+ * coder.encode({ a: { value: 0x1234 }, b: { value: 0x5678 } }, buffer);
+ * const [decoded] = coder.decode(buffer);
+ *
+ * assertEquals(decoded.a.value, 0x1234);
+ * assertEquals(decoded.b.value, 0x5678);
+ * ```
+ *
+ * @module
+ */
+
+import type { Coder } from "../core.ts";
+import { decode, encode } from "../helpers.ts";
+import type { Refiner } from "./refine.ts";
+
+/**
+ * Map of host field names to the sub-coder that decodes/encodes that field's
+ * bytes. Used as the input to {@linkcode refineFields}.
+ *
+ * The element coder is `Coder<any>` so refiners with mixed inner-payload
+ * types compose without forcing the caller to widen each entry. The
+ * decoded value type for each field is recovered via {@linkcode DecodedFields}.
+ */
+// deno-lint-ignore no-explicit-any
+export type FieldCoders = Record<string, Coder<any>>;
+
+/**
+ * Mapped type extracting the decoded value type for each entry in a
+ * {@linkcode FieldCoders} map. Given `{ payload: Coder<Ipv4> }` it yields
+ * `{ payload: Ipv4 }`.
+ */
+export type DecodedFields<TCoders extends FieldCoders> = {
+  [K in keyof TCoders]: TCoders[K] extends Coder<infer T> ? T : never;
+};
+
+/**
+ * Creates a {@linkcode Refiner} that swaps named `Uint8Array` fields of a
+ * host record for the typed values produced by their sub-coders. Fields not
+ * in `coders` are passed through unchanged.
+ *
+ * Pair with {@linkcode refine} to apply the refinement to a host coder, or
+ * use as an arm of {@linkcode refineSwitch} for layered formats where the
+ * host's discriminator picks which sub-coder to use.
+ *
+ * @template TCoders - Map of field name to sub-coder.
+ * @template THost - Host record; constrained so each refined field is
+ *   `Uint8Array` on the unrefined side.
+ *
+ * @param coders - Map of field names to per-field sub-coders.
+ * @returns A refiner from `THost` to `THost` with the listed fields replaced
+ *   by their decoded values.
+ *
+ * @example Refine a payload field with a nested coder
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { bytes, refine, refineFields, struct, u16be, u8 } from "@hertzg/binstruct";
+ *
+ * const inner = struct({ a: u8(), b: u8() });
+ * const outer = struct({ tag: u16be(), payload: bytes(2) });
+ *
+ * const coder = refine(outer, refineFields({ payload: inner }))();
+ * const buffer = new Uint8Array(4);
+ *
+ * coder.encode({ tag: 0xbeef, payload: { a: 1, b: 2 } }, buffer);
+ * const [decoded] = coder.decode(buffer);
+ *
+ * assertEquals(decoded, { tag: 0xbeef, payload: { a: 1, b: 2 } });
+ * ```
+ */
+export function refineFields<
+  TCoders extends FieldCoders,
+  THost extends { [K in keyof TCoders]: Uint8Array },
+>(
+  coders: TCoders,
+): Refiner<THost, Omit<THost, keyof TCoders> & DecodedFields<TCoders>, []> {
+  type TRefined = Omit<THost, keyof TCoders> & DecodedFields<TCoders>;
+  const fields = Object.keys(coders);
+  return {
+    refine: (host, ctx) => {
+      const out: Record<string, unknown> = { ...host };
+      for (const field of fields) {
+        out[field] = decode(
+          coders[field],
+          host[field as keyof THost] as Uint8Array,
+          ctx,
+        );
+      }
+      return out as TRefined;
+    },
+    unrefine: (refined, ctx) => {
+      const out: Record<string, unknown> = { ...refined };
+      for (const field of fields) {
+        out[field] = encode(
+          coders[field],
+          (refined as Record<string, unknown>)[field],
+          ctx,
+        );
+      }
+      return out as THost;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `refineFields(coders)` — a refiner factory that swaps named `Uint8Array` fields of a host record for the typed values produced by per-field sub-coders.
- Sits next to `refine` and `refineSwitch` as the single-pass primitive for layered binary formats whose host record carries one or more raw-bytes payloads.
- Exposes `refineFields`, `FieldCoders`, and `DecodedFields<T>`.

## Why

Layered binary formats (Ethernet → IPv4 → UDP, PNG-like chunked containers, custom envelopes with payload bytes) repeatedly need the same shape: take a struct whose `payload` field holds bytes, run another coder on those bytes, surface the typed value in place. Today that's a hand-written `Refiner` per layer. `refineFields` is the building block — one helper that handles single-field and multi-field cases, composes cleanly with `refineSwitch` arms.

```ts
import { bytes, refine, refineFields, struct, u16be, u8 } from "@hertzg/binstruct";

const inner = struct({ a: u8(), b: u8() });
const outer = struct({ tag: u16be(), payload: bytes(2) });

const coder = refine(outer, refineFields({ payload: inner }))();
// Coder<{ tag: number; payload: { a: number; b: number } }>
```

Multi-field works the same way — every entry in the coder map names a host field whose value is `Uint8Array`; fields not listed pass through unchanged.

## Test plan

- [x] `deno task lint` clean
- [x] `deno task test` clean (project-wide, including doc examples)
- [x] Unit coverage in `refine/fields.test.ts`:
  - single-field round-trip
  - multi-field round-trip
  - pass-through of unlisted fields
  - composition with `refineSwitch`
  - empty coder map (identity)

## Notes

- The `FieldCoders = Record<string, Coder<any>>` element uses `any` (with `// deno-lint-ignore no-explicit-any`) to match the convention used by `RefinedUnion`'s `Refiner<any, any, any>` — needed for the input map to accept coders with mixed inner-payload types without the caller widening each entry.
- Two `as` casts inside the implementation (no `as unknown as`) at the type-construction boundary; required because TS can't track computed-key spread through generic field names.