### PR TITLE
chore: scaffold agent-skills configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 deno.lock
 cov/
-docs/
+docs/*
+!docs/agents/
 
 # coverage
 coverage/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -475,3 +475,21 @@ const fileWithPadding = struct({
   )),
 });
 ```
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues via `gh`, on `hertzg/jsr-monorepo`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical labels, no overrides: `needs-triage`, `needs-info`,
+`ready-for-agent`, `ready-for-human`, `wontfix`. See
+`docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Multi-context: root-level decisions in `adr/`, per-package decisions in
+`packages/<scope>/<name>/adr/`. `CONTEXT-MAP.md` at the root, per-package
+`CONTEXT.md` files created lazily. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,67 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation
+when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT-MAP.md`** at the repo root if it exists — points at one
+  `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`packages/<scope>/<name>/CONTEXT.md`** for the package(s) you're
+  working in.
+- **`adr/`** at the repo root — repo-wide decisions (tooling, conventions,
+  monorepo structure).
+- **`packages/<scope>/<name>/adr/`** — package-specific decisions
+  (binstruct, ip, png, routeros-api, tplink-api, xhb each have their own).
+
+If any of these files don't exist, **proceed silently**. Don't flag their
+absence; don't suggest creating them upfront. The producer skill
+(`/grill-with-docs`) creates them lazily when terms or decisions actually
+get resolved.
+
+## File structure (this repo — multi-context)
+
+```
+/
+├── CONTEXT-MAP.md                                   ← created lazily
+├── adr/                                             ← repo-wide decisions
+│   ├── 0001-bare-imports-via-import-map.md
+│   ├── …
+│   └── 0010-sub-entrypoint-exports.md
+└── packages/
+    ├── @hertzg/
+    │   ├── binstruct/
+    │   │   ├── CONTEXT.md                           ← created lazily
+    │   │   ├── adr/                                 ← package decisions
+    │   │   └── …
+    │   ├── ip/
+    │   │   ├── CONTEXT.md                           ← created lazily
+    │   │   └── adr/
+    │   └── …
+    └── @binstruct/
+        ├── png/
+        │   └── adr/
+        └── …
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor
+proposal, a hypothesis, a test name), use the term as defined in
+`CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal —
+either you're inventing language the project doesn't use (reconsider) or
+there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather
+than silently overriding:
+
+> _Contradicts repo ADR 0006 (no defensive programming) — but worth
+> reopening because…_
+
+When citing an ADR, qualify the scope: "**repo ADR 0009**" for root-level,
+"**`@hertzg/binstruct` ADR 0005**" for package-level. ADR numbers reset per
+scope.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,28 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues on `hertzg/jsr-monorepo`.
+Use the `gh` CLI for all operations — it auto-detects the repo from
+`git remote -v`.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a
+  heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments
+  by `jq` and also fetching labels.
+- **List issues**:
+  `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`
+  with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**:
+  `gh issue edit <number> --add-label "..."` /
+  `gh issue edit <number> --remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,16 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps
+those roles to the actual label strings used in this repo's issue tracker.
+
+| Canonical role     | Label in this repo  | Meaning                                  |
+| ------------------ | ------------------- | ---------------------------------------- |
+| `needs-triage`     | `needs-triage`      | Maintainer needs to evaluate this issue  |
+| `needs-info`       | `needs-info`        | Waiting on reporter for more information |
+| `ready-for-agent`  | `ready-for-agent`   | Fully specified, ready for an AFK agent  |
+| `ready-for-human`  | `ready-for-human`   | Requires human implementation            |
+| `wontfix`          | `wontfix`           | Will not be actioned                     |
+
+All five labels exist on GitHub. When a skill mentions a role
+(e.g. "apply the AFK-ready triage label"), use the corresponding label
+string from this table.


### PR DESCRIPTION
## Summary

Set up the per-repo configuration that Matt Pocock's engineering skills assume:

- **Issue tracker** — GitHub Issues via \`gh\`, on \`hertzg/jsr-monorepo\`.
- **Triage labels** — five canonical labels (\`needs-triage\`, \`needs-info\`, \`ready-for-agent\`, \`ready-for-human\`, \`wontfix\`), already created on GitHub with a yellow / orange / green / blue / grey colour scheme.
- **Domain docs** — multi-context layout matching the existing ADR structure: repo-wide decisions in \`adr/\`, package-specific decisions in \`packages/<scope>/<name>/adr/\`. \`CONTEXT-MAP.md\` and per-package \`CONTEXT.md\` files will be created lazily by \`/grill-with-docs\` when terms or decisions get resolved.

Adds an \`## Agent skills\` section to \`AGENTS.md\` pointing at the three new docs in \`docs/agents/\`. The \`docs/\` directory was previously fully gitignored (it's where \`deno doc\` would output HTML); the .gitignore now ignores \`docs/*\` with a \`!docs/agents/\` exception so only the agent docs are tracked.

## Test plan

- [ ] Skim the three new \`docs/agents/*.md\` files for accuracy
- [ ] Verify the five GitHub labels exist with the right colours/descriptions
- [ ] Confirm \`deno task lint\` and \`deno task test\` still pass (no code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)