### PR TITLE
feat(@hertzg/xhb)!: remove parse hooks

### DIFF
--- a/packages/@hertzg/xhb/adr/0004-no-parse-hooks-xml-parser-is-internal.md
+++ b/packages/@hertzg/xhb/adr/0004-no-parse-hooks-xml-parser-is-internal.md
@@ -1,0 +1,82 @@
+# ADR 0004 — No parse hooks; the XML parser is an internal detail
+
+**Status:** Accepted
+
+**Supersedes:** the `ParseOptions` hooks introduced with the initial public API.
+
+## Context
+
+`parse` accepted a `ParseOptions` object with two hooks:
+
+```ts ignore
+export interface ParseOptions {
+  onEntity?: <T>(entity: T, node: XmlElement) => T;
+  onUnknownNode?: (node: XmlElement) => void;
+}
+```
+
+Both took an `XmlElement` — a type owned by `@std/xml`. That made `@std/xml`
+part of this package's public API surface, and it was the only place where it
+was. Everything else about the XML layer is private: `parse`/`isElement` are
+used internally, the per-entity `parseX` functions take `XmlElement` but are not
+re-exported from `mod.ts`, and `SerializeOptions.onEntity` deals in strings.
+
+The consequences of that single leak were larger than the feature:
+
+- **Type coupling.** A consumer who wanted to write the handler as anything
+  other than an inline arrow — a named function, a stored variable, an explicit
+  annotation, their own wrapper type — had to add `@std/xml` to their own import
+  map to name `XmlElement`.
+- **Runtime coupling.** The hooks received the parser's actual node objects, so
+  consumers observed `@std/xml`'s representation (`node.name.local`,
+  `node.attributes`) directly. A shape change in `@std/xml` therefore became a
+  breaking change for _this_ package's consumers, even though the dependency was
+  nominally private. That is a real maintenance obligation: every `@std/xml`
+  bump has to be reviewed against a contract we never intended to publish.
+- **Cost out of proportion to value.** `onEntity` is
+  `<T>(entity: T, node: XmlElement) => T`; by parametricity that signature
+  promises the hook cannot actually transform anything, so the type never
+  described the intended use in the first place. `onUnknownNode` reported nodes
+  this library deliberately ignores. Both are escape hatches — the kind of API
+  that pins down internals in exchange for a use case nobody has articulated.
+
+## Decision
+
+Remove `ParseOptions` entirely. `parse` takes a single argument:
+
+```ts ignore
+export function parse(xml: string): XHB;
+```
+
+Unrecognized nodes are ignored silently, as before — the hook only ever observed
+that, it never changed it.
+
+`@std/xml` is now a fully internal implementation detail of `@hertzg/xhb`. No
+type or value from it appears anywhere in the public surface reported by
+`deno doc`.
+
+`SerializeOptions.onEntity` is unaffected: it deals in the entity and its
+serialized `string`, so it leaks nothing.
+
+## Consequences
+
+- **Breaking change.** Any caller passing a second argument to `parse` fails to
+  compile. There is no deprecation period; the package is small and the hooks
+  were undocumented beyond a one-line JSDoc.
+- **`@std/xml` can now be upgraded on its own merits.** Its version is a private
+  dependency decision, reviewable against this package's tests rather than
+  against unknown consumer code.
+- **Transformation moves to where it belongs.** A consumer who wants to
+  post-process entities can map over `xhb.accounts`, `xhb.operations`, etc.
+  after `parse` returns — with fully typed entity objects instead of raw XML
+  nodes, which is strictly more ergonomic than the hook was.
+- **Observing unknown nodes is no longer possible.** If a real need appears
+  (e.g. reporting XHB elements this library does not yet model), it should be
+  re-introduced deliberately — reporting a package-owned shape such as the tag
+  name and its attributes, never the parser's node type.
+
+## References
+
+- `mod.ts` — `parse`, `SerializeOptions`
+- ADR 0001 — Round-trip byte fidelity
+- ADR 0003 — Module layout mirrors the C source

--- a/packages/@hertzg/xhb/mod.ts
+++ b/packages/@hertzg/xhb/mod.ts
@@ -13,8 +13,8 @@
  * - **Serialize** an {@linkcode XHB} object back to XML
  * - All HomeBank entity types: accounts, archives, assigns, categories,
  *   currencies, operations, payees, properties, tags
- * - Hooks for custom entity processing via {@linkcode ParseOptions.onEntity}
- *   and {@linkcode SerializeOptions.onEntity}
+ * - A hook for post-processing serialized entities via
+ *   {@linkcode SerializeOptions.onEntity}
  *
  * @example Parse an XHB string and inspect its contents
  * ```ts
@@ -97,7 +97,7 @@
  * @module
  */
 
-import { isElement, parse as parseXml, type XmlElement } from "@std/xml";
+import { isElement, parse as parseXml } from "@std/xml";
 import {
   parseProperties,
   type Properties,
@@ -178,30 +178,16 @@ const NODE_NAME_CURRENCY = "cur";
 const NODE_NAME_TAG = "tag";
 const NODE_NAME_OPERATION = "ope";
 
-/** Options for {@linkcode parse}. */
-export interface ParseOptions {
-  /** Called for each parsed entity, allowing transformation before storage. */
-  onEntity?: <T>(entity: T, node: XmlElement) => T;
-  /** Called when an unrecognized XML node is encountered. */
-  onUnknownNode?: (node: XmlElement) => void;
-}
-
-const defaultParseOnEntity = <T>(entity: T): T => entity;
-const defaultParseOnUnknownNode = (): void => undefined;
-
 /**
  * Parses an XHB XML string into a typed {@linkcode XHB} object.
  *
+ * Nodes that are not recognized HomeBank entities are ignored.
+ *
  * @param xml - The raw XHB XML string.
- * @param options - Optional parse hooks.
  * @returns The parsed XHB object.
  */
-export function parse(xml: string, options: ParseOptions = {}): XHB {
-  const doc = parseXml(xml, { ignoreWhitespace: true }),
-    opts: Required<ParseOptions> = {
-      onEntity: options.onEntity || defaultParseOnEntity,
-      onUnknownNode: options.onUnknownNode || defaultParseOnUnknownNode,
-    };
+export function parse(xml: string): XHB {
+  const doc = parseXml(xml, { ignoreWhitespace: true });
 
   const xhb: XHB = {
     versions: parseVersions(doc.root),
@@ -216,37 +202,35 @@ export function parse(xml: string, options: ParseOptions = {}): XHB {
     tags: [],
   };
 
-  doc.root.children.filter(isElement).forEach((node: XmlElement) => {
+  doc.root.children.filter(isElement).forEach((node) => {
     switch (node.name.local) {
       case NODE_NAME_ACCOUNT:
-        xhb.accounts.push(opts.onEntity(parseAccount(node), node));
+        xhb.accounts.push(parseAccount(node));
         break;
       case NODE_NAME_ARCHIVE:
-        xhb.archives.push(opts.onEntity(parseArchive(node), node));
+        xhb.archives.push(parseArchive(node));
         break;
       case NODE_NAME_ASSIGN:
-        xhb.assigns.push(opts.onEntity(parseAssign(node, xhb), node));
+        xhb.assigns.push(parseAssign(node, xhb));
         break;
       case NODE_NAME_PAYEE:
-        xhb.payees.push(opts.onEntity(parsePayee(node), node));
+        xhb.payees.push(parsePayee(node));
         break;
       case NODE_NAME_PROPERTIES:
-        xhb.properties = opts.onEntity(parseProperties(node), node);
+        xhb.properties = parseProperties(node);
         break;
       case NODE_NAME_CATEGORY:
-        xhb.categories.push(opts.onEntity(parseCategory(node), node));
+        xhb.categories.push(parseCategory(node));
         break;
       case NODE_NAME_CURRENCY:
-        xhb.currencies.push(opts.onEntity(parseCurrency(node), node));
+        xhb.currencies.push(parseCurrency(node));
         break;
       case NODE_NAME_TAG:
-        xhb.tags.push(opts.onEntity(parseTag(node), node));
+        xhb.tags.push(parseTag(node));
         break;
       case NODE_NAME_OPERATION:
-        xhb.operations.push(opts.onEntity(parseOperation(node), node));
+        xhb.operations.push(parseOperation(node));
         break;
-      default:
-        opts.onUnknownNode(node);
     }
   });
 


### PR DESCRIPTION
Removes `ParseOptions` and its `onEntity` / `onUnknownNode` hooks. `parse` now takes a single argument.

## Why

These hooks were the only place `@std/xml` reached the public API of `@hertzg/xhb`. Of the 98 public symbols `deno doc` reports for `mod.ts`, `ParseOptions` was the sole one mentioning `XmlElement`; it is now zero.

Two costs, the second being the one that mattered:

- **Type coupling.** Inline arrow callbacks inferred fine, but a consumer who named the handler, annotated it, or wrapped it in their own type had to add `@std/xml` to their own import map — a transitive dependency the package otherwise hides.
- **Runtime coupling.** The hooks were handed the parser's actual node objects, so consumers observed `@std/xml`'s representation (`node.name.local`, `node.attributes`) directly. That made any shape change in `@std/xml` a potential breaking change for downstream code, turning a private dependency into a contract we never meant to publish.

The feature itself did not pay for that. `onEntity` was typed `<T>(entity: T, node: XmlElement) => T` — by parametricity that signature promises the hook *cannot* transform anything, so it never described its intended use. `onUnknownNode` reported nodes the library deliberately ignores.

## Migration

Post-process the returned object instead — with fully typed entities rather than raw XML nodes:

```ts
// before
const xhb = parse(xml, { onEntity: (e) => tweak(e) });

// after
const xhb = parse(xml);
xhb.operations = xhb.operations.map(tweak);
```

Observing unknown nodes has no replacement. If a real need appears it should be re-introduced reporting a package-owned shape (tag name + attributes), never the parser's node type — noted in the ADR.

`SerializeOptions.onEntity` is unchanged: it deals in the entity and its serialized string, so it leaks nothing. Happy to remove it in the same major if you'd rather the API be symmetric.

## Notes

- ADR 0004 added recording the decision and the reasoning.
- `deno task lint` and `deno task test` pass from the repo root.
- Independent of #182; that bump needs no code changes either way.