### PR TITLE
chore(@hertzg/xhb): add a real test suite

### DIFF
--- a/packages/@hertzg/xhb/_parse.test.ts
+++ b/packages/@hertzg/xhb/_parse.test.ts
@@ -1,0 +1,54 @@
+import { assertEquals } from "@std/assert";
+import { atoi, parseGCharP, parseGDouble } from "./_parse.ts";
+
+// HomeBank omits an attribute rather than writing an empty one, so every
+// parse primitive is routinely handed `undefined` even though the XML
+// attribute map is typed as `Record<string, string>`.
+const OMITTED = undefined as unknown as string;
+
+Deno.test("atoi turns an omitted attribute into 0, which is what makes round-trip work", () => {
+  // The serializer drops integer attributes equal to 0, so "missing" and "0"
+  // are the same value in both directions (ADR 0001).
+  assertEquals(atoi(OMITTED), 0);
+  assertEquals(atoi(null as unknown as string), 0);
+});
+
+Deno.test("atoi reads leading digits and stops, like C atoi", () => {
+  assertEquals(atoi("42"), 42);
+  assertEquals(atoi("-30"), -30);
+  assertEquals(atoi("12abc"), 12);
+
+  // The `d` version attribute is written zero-padded; leading zeros are
+  // decimal, not octal.
+  assertEquals(atoi("050402"), 50402);
+});
+
+Deno.test("atoi returns NaN for an attribute that is present but not a number", () => {
+  // Only *missing* attributes become 0. A present-but-garbage attribute is
+  // passed through as NaN rather than being silently repaired — the library
+  // does not clean up input (ADR 0001).
+  assertEquals(atoi(""), NaN);
+  assertEquals(atoi("abc"), NaN);
+});
+
+Deno.test("parseGDouble keeps the original text so precision survives the round trip", () => {
+  // HomeBank writes C doubles at full precision. Parsing these through
+  // Number() would give 76.22 / 1.4 and re-serialize shorter strings, so
+  // gDouble is a string end to end (ADR 0002).
+  assertEquals(parseGDouble("76.219999999999999"), "76.219999999999999");
+  assertEquals(parseGDouble("1.3999999999999999"), "1.3999999999999999");
+  assertEquals(
+    parseGDouble("0.00020000000000000001"),
+    "0.00020000000000000001",
+  );
+  assertEquals(parseGDouble("-42.5"), "-42.5");
+});
+
+Deno.test("parseGCharP passes text through and leaves an omitted attribute undefined", () => {
+  assertEquals(parseGCharP("Cheque Account"), "Cheque Account");
+
+  // An empty attribute is a real empty string; a missing one is undefined,
+  // and the serializer only drops the latter.
+  assertEquals(parseGCharP(""), "");
+  assertEquals(parseGCharP(OMITTED), undefined);
+});

--- a/packages/@hertzg/xhb/_serialize.test.ts
+++ b/packages/@hertzg/xhb/_serialize.test.ts
@@ -1,0 +1,125 @@
+import { assertEquals } from "@std/assert";
+import {
+  dtostr,
+  hb_escape_text,
+  hb_xml_attr_amt,
+  hb_xml_attr_int,
+  hb_xml_attr_int0,
+  hb_xml_attr_txt,
+  hb_xml_attr_txt_crlf,
+  hb_xml_attrs_splits,
+  hb_xml_tag,
+  tags_toStr,
+} from "./_serialize.ts";
+
+// See the note in `_parse.test.ts`: omitted attributes reach the serializers
+// as `undefined`.
+const OMITTED = undefined as unknown as string;
+
+Deno.test("hb_xml_attr_int omits an attribute whose value is 0", () => {
+  // This is the single most load-bearing rule for byte fidelity: HomeBank
+  // writes `cheque1="8760951"` but writes nothing at all for a zero
+  // cheque number (ADR 0001).
+  assertEquals(hb_xml_attr_int("cheque1", 8760951), 'cheque1="8760951"');
+  assertEquals(hb_xml_attr_int("cheque1", 0), "");
+});
+
+Deno.test("hb_xml_attr_int0 writes the attribute even when it is 0", () => {
+  // A handful of attributes are always written — `<properties auto_smode>`
+  // is the one that uses this in practice.
+  assertEquals(hb_xml_attr_int0("auto_smode", 0), 'auto_smode="0"');
+  assertEquals(hb_xml_attr_int0("auto_smode", 1), 'auto_smode="1"');
+});
+
+Deno.test("hb_xml_attr_txt drops a missing value but keeps an empty one", () => {
+  assertEquals(hb_xml_attr_txt("name", "Amazon"), 'name="Amazon"');
+  assertEquals(hb_xml_attr_txt("name", ""), 'name=""');
+  assertEquals(hb_xml_attr_txt("name", OMITTED), "");
+});
+
+Deno.test("amounts are written back as the exact text they were read as", () => {
+  // dtostr is the identity because gDouble is already a string (ADR 0002);
+  // there is deliberately no number formatting step here.
+  assertEquals(dtostr("76.219999999999999"), "76.219999999999999");
+  assertEquals(
+    hb_xml_attr_amt("initial", "76.219999999999999"),
+    'initial="76.219999999999999"',
+  );
+
+  // Unlike integers, a zero amount is still written.
+  assertEquals(hb_xml_attr_amt("minimum", "0"), 'minimum="0"');
+  assertEquals(hb_xml_attr_amt("minimum", OMITTED), "");
+});
+
+Deno.test("hb_xml_tag joins the surviving attributes into a self-closing tag", () => {
+  assertEquals(
+    hb_xml_tag("<pay", 'key="1"', "", 'name="Amazon"', ""),
+    '<pay key="1" name="Amazon"/>',
+  );
+
+  // Every attribute dropped means no space before the slash.
+  assertEquals(hb_xml_tag("<ope", "", ""), "<ope/>");
+});
+
+Deno.test("hb_escape_text escapes the five XML metacharacters as named entities", () => {
+  assertEquals(hb_escape_text(`&<>'"`), "&amp;&lt;&gt;&apos;&quot;");
+});
+
+Deno.test("hb_escape_text escapes control characters as numeric entities", () => {
+  assertEquals(hb_escape_text("a\nb"), "a&#xa;b");
+  assertEquals(hb_escape_text("a\r\nb"), "a&#xd;&#xa;b");
+  assertEquals(hb_escape_text("a\x1bb"), "a&#x1b;b");
+  assertEquals(hb_escape_text("a\x7fb"), "a&#x7f;b");
+  assertEquals(hb_escape_text("a\x9fb"), "a&#x9f;b");
+});
+
+Deno.test("hb_escape_text leaves tab, U+0085 and non-ASCII text alone", () => {
+  // The escaped ranges are 0x01-0x08, 0x0a-0x1f, 0x7f-0x84 and 0x86-0x9f.
+  // Tab (0x09) and NEL (0x85) fall in the gaps; this mirrors HomeBank's
+  // hb_xml_escape_text exactly (ADR 0003) and must not be "tidied up".
+  assertEquals(hb_escape_text("a\tb"), "a\tb");
+  assertEquals(hb_escape_text("a\x85b"), "a\x85b");
+  assertEquals(hb_escape_text("héllo €"), "héllo €");
+});
+
+Deno.test("only hb_xml_attr_txt_crlf escapes; plain text attributes are written raw", () => {
+  // HomeBank has two text writers and uses the escaping one for exactly one
+  // field (`<account notes>`). An ampersand in a payee or account *name* is
+  // therefore emitted unescaped. That is a faithful copy of the C original
+  // (ADR 0001/0003), not an oversight to fix here.
+  assertEquals(hb_xml_attr_txt("name", "Ben & Jerry"), 'name="Ben & Jerry"');
+  assertEquals(
+    hb_xml_attr_txt_crlf("notes", "Ben & Jerry\nsecond line"),
+    'notes="Ben &amp; Jerry&#xa;second line"',
+  );
+});
+
+Deno.test("tags_toStr joins tag names with spaces", () => {
+  assertEquals(tags_toStr(["groceries", "weekly"]), "groceries weekly");
+  assertEquals(tags_toStr([]), "");
+});
+
+Deno.test("splits are written as three parallel ||-separated attributes", () => {
+  // One `<ope>` attribute per split column: categories, amounts, memos.
+  // The i-th split is the i-th entry of each list, so an empty memo still
+  // has to occupy its slot.
+  assertEquals(
+    hb_xml_attrs_splits([
+      { cat: 12, amt: "-15.5", mem: "bread" },
+      { cat: 13, amt: "-4.5", mem: "" },
+    ]),
+    'scat="12||13" samt="-15.5||-4.5" smem="bread||"',
+  );
+
+  assertEquals(hb_xml_attrs_splits([]), "");
+});
+
+Deno.test("a pipe in a split memo would break the framing, so the first one is stripped", () => {
+  // `|` is removed from split memos because it would corrupt the `||`
+  // framing above — but only the first occurrence is removed. Mirrors the C
+  // original (ADR 0001/0003); asserted here as-is rather than fixed.
+  assertEquals(
+    hb_xml_attrs_splits([{ cat: 1, amt: "-1", mem: "a|b|c" }]),
+    'scat="1" samt="-1" smem="ab|c"',
+  );
+});

--- a/packages/@hertzg/xhb/account.test.ts
+++ b/packages/@hertzg/xhb/account.test.ts
@@ -1,0 +1,89 @@
+import { assertEquals } from "@std/assert";
+import { parse, serialize } from "./mod.ts";
+import { ACCOUNT_TYPE_BANK, serializeAccount } from "./account.ts";
+
+// HomeBank omits an attribute instead of writing an empty one, so a parsed
+// entity holds `undefined` wherever the XML had nothing.
+const OMITTED = undefined as unknown as string;
+
+Deno.test("parseAccount renames the terse XHB attributes to descriptive properties", () => {
+  const xml = [
+    '<?xml version="1.0"?>',
+    '<homebank v="1.3" d="050402">',
+    '<account key="1" pos="1" type="1" curr="1" name="Cheque Account" number="01548726554" bankname="Amiga Universal Bank" initial="76.219999999999999" minimum="-30.489999999999998" cheque1="8760951"/>',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  assertEquals(parse(xml).accounts[0], {
+    key: 1,
+    // `flags`, `cheque2` and `tpl` were omitted from the XML, so they parse
+    // to 0 and serialize back to nothing at all (ADR 0001).
+    flags: 0,
+    displayPosition: 1,
+    type: ACCOUNT_TYPE_BANK,
+    currency: 1,
+    name: "Cheque Account",
+    bankNumber: "01548726554",
+    bankName: "Amiga Universal Bank",
+    // Balances keep their C-double text; Number() would round these to
+    // 76.22 and -30.49 (ADR 0002).
+    startingBalance: "76.219999999999999",
+    overdraftLimit: "-30.489999999999998",
+    chequeBookNumber1: 8760951,
+    chequeBookNumber2: 0,
+    // An omitted text attribute is undefined, not "" — the difference
+    // decides whether it is written back out.
+    notes: OMITTED,
+    defaultTemplate: 0,
+  });
+
+  assertEquals(serialize(parse(xml)), xml);
+});
+
+Deno.test("serializeAccount omits every zero-valued integer attribute", () => {
+  assertEquals(
+    serializeAccount({
+      key: 4,
+      flags: 0,
+      displayPosition: 4,
+      type: 0,
+      currency: 4,
+      name: "Bitcoin Account",
+      bankNumber: OMITTED,
+      bankName: OMITTED,
+      startingBalance: "0.41999999999999998",
+      overdraftLimit: "0",
+      chequeBookNumber1: 0,
+      chequeBookNumber2: 0,
+      notes: OMITTED,
+      defaultTemplate: 0,
+    }),
+    // No flags, no type, no cheque numbers, no tpl — but `minimum="0"`
+    // stays, because amounts are text and only integers are dropped at 0.
+    '<account key="4" pos="4" curr="4" name="Bitcoin Account" initial="0.41999999999999998" minimum="0"/>',
+  );
+});
+
+Deno.test("notes are the only account text that gets XML-escaped", () => {
+  const xml = [
+    '<?xml version="1.0"?>',
+    '<homebank v="1.3" d="050402">',
+    '<account key="1" name="R&amp;D" notes="paid &amp; done&#xa;line two"/>',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  const account = parse(xml).accounts[0];
+  assertEquals(account.name, "R&D");
+  assertEquals(account.notes, "paid & done\nline two");
+
+  // HomeBank writes `notes` through its escaping helper and every other
+  // text attribute raw, so the ampersand in `name` comes back unescaped
+  // while the one in `notes` does not. Faithful to the C original
+  // (ADR 0001/0003) even though it makes the output non-well-formed XML.
+  assertEquals(
+    serialize(parse(xml)).split("\n")[2],
+    '<account key="1" name="R&D" notes="paid &amp; done&#xa;line two"/>',
+  );
+});

--- a/packages/@hertzg/xhb/archive.test.ts
+++ b/packages/@hertzg/xhb/archive.test.ts
@@ -1,0 +1,65 @@
+import { assertEquals } from "@std/assert";
+import { parse, serialize } from "./mod.ts";
+import {
+  ARCHIVE_FLAG_AUTO,
+  ARCHIVE_FLAG_SPLIT,
+  SCHEDULED_EVERY_UNIT_MONTH,
+  SCHEDULED_WEEKEND_AFTER,
+} from "./archive.ts";
+import { PAY_MODE_XFER } from "./operation.ts";
+
+Deno.test("a <fav> is a transaction template plus a schedule", () => {
+  const xml = [
+    '<?xml version="1.0"?>',
+    '<homebank v="1.3" d="050402">',
+    '<fav key="9" amount="-15" account="1" paymode="4" flags="4" payee="22" category="41" wording="Recurring Donation" nextdate="731961" every="1" unit="2" limit="1" weekend="2"/>',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  assertEquals(parse(xml).archives[0], {
+    key: 9,
+    amount: "-15",
+    account: 1,
+    destinationAccount: 0,
+    payMode: PAY_MODE_XFER,
+    status: 0,
+    // Set to auto-insert rather than only reminding.
+    flags: ARCHIVE_FLAG_AUTO,
+    payee: 22,
+    category: 41,
+    memo: "Recurring Donation",
+    tags: [],
+    // Every 1 month, moved to the Monday after if it lands on a weekend,
+    // stopping after 1 more occurrence.
+    scheduledNextDate: 731961,
+    scheduledEveryNumber: 1,
+    scheduledEveryUnit: SCHEDULED_EVERY_UNIT_MONTH,
+    scheduledStopAfter: 1,
+    scheduledWeekend: SCHEDULED_WEEKEND_AFTER,
+    scheduledGap: 0,
+    splits: [],
+  });
+
+  assertEquals(serialize(parse(xml)), xml);
+});
+
+Deno.test("archives use the same ||-framed splits as operations and set ARCHIVE_FLAG_SPLIT", () => {
+  const xml = [
+    '<?xml version="1.0"?>',
+    '<homebank v="1.3" d="050402">',
+    '<fav key="1" amount="-30" account="1" flags="256" wording="Monthly bills" nextdate="731341" every="1" unit="2" scat="33||41" samt="-20||-10" smem="rent||"/>',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  const [archive] = parse(xml).archives;
+
+  assertEquals(archive.splits, [
+    { category: 33, amount: "-20", memo: "rent" },
+    { category: 41, amount: "-10", memo: "" },
+  ]);
+  assertEquals(archive.flags, ARCHIVE_FLAG_SPLIT);
+
+  assertEquals(serialize(parse(xml)), xml);
+});

--- a/packages/@hertzg/xhb/assign.test.ts
+++ b/packages/@hertzg/xhb/assign.test.ts
@@ -1,0 +1,80 @@
+import { assertEquals } from "@std/assert";
+import { parse, serialize } from "./mod.ts";
+import {
+  ASSIGN_FIELD_PAYEE,
+  ASSIGN_FLAG_DOCAT,
+  ASSIGN_FLAG_DOPAY,
+  ASSIGN_FLAG_EXACT,
+} from "./assign.ts";
+import { PAY_MODE_CASH } from "./operation.ts";
+
+Deno.test("an <asg> rule matches imported transactions and fills in the blanks", () => {
+  const xml = [
+    '<?xml version="1.0"?>',
+    '<homebank v="1.3" d="050402">',
+    '<asg key="1" flags="6" field="1" name="Shell" payee="7" category="2" paymode="3"/>',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  assertEquals(parse(xml).assigns[0], {
+    key: 1,
+    // Assign both a payee and a category when the rule matches.
+    flags: ASSIGN_FLAG_DOPAY | ASSIGN_FLAG_DOCAT,
+    field: ASSIGN_FIELD_PAYEE,
+    name: "Shell",
+    payee: 7,
+    category: 2,
+    payMode: PAY_MODE_CASH,
+  });
+
+  assertEquals(serialize(parse(xml)), xml);
+});
+
+Deno.test("format version 0.7 and older keep `exact` as its own attribute, later versions as a flag", () => {
+  const xml = [
+    '<?xml version="1.0"?>',
+    '<homebank v="0.7" d="030000">',
+    '<asg key="1" name="Shell" exact="1"/>',
+    '<asg key="2" name="Amazon"/>',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  const [shell, amazon] = parse(xml).assigns;
+
+  // On these old files the flags attribute does not exist yet, so it is
+  // reconstructed: pre-0.8 rules always assigned payee and category, and
+  // `exact="1"` becomes ASSIGN_FLAG_EXACT.
+  assertEquals(
+    shell.flags,
+    ASSIGN_FLAG_DOPAY | ASSIGN_FLAG_DOCAT | ASSIGN_FLAG_EXACT,
+  );
+  assertEquals(amazon.flags, ASSIGN_FLAG_DOPAY | ASSIGN_FLAG_DOCAT);
+});
+
+Deno.test("the 0.7 migration overwrites whatever flags a newer-looking file carried", () => {
+  const oldFormat = [
+    '<?xml version="1.0"?>',
+    '<homebank v="0.7" d="030000">',
+    '<asg key="1" flags="2048" name="Shell"/>',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  const currentFormat = [
+    '<?xml version="1.0"?>',
+    '<homebank v="1.3" d="050402">',
+    '<asg key="1" flags="2048" name="Shell"/>',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  // The version check is on the file, not the element: at v0.7 the flags
+  // attribute is discarded and rebuilt, at v1.3 it is taken at face value.
+  assertEquals(
+    parse(oldFormat).assigns[0].flags,
+    ASSIGN_FLAG_DOPAY | ASSIGN_FLAG_DOCAT,
+  );
+  assertEquals(parse(currentFormat).assigns[0].flags, 2048);
+});

--- a/packages/@hertzg/xhb/category.test.ts
+++ b/packages/@hertzg/xhb/category.test.ts
@@ -1,0 +1,66 @@
+import { assertEquals } from "@std/assert";
+import { parse, serialize } from "./mod.ts";
+import { CATEGORY_FLAG_BUDGET, CATEGORY_FLAG_SUB } from "./category.ts";
+
+Deno.test("a category is a name, an optional parent and a budget table", () => {
+  const xml = [
+    '<?xml version="1.0"?>',
+    '<homebank v="1.3" d="050402">',
+    '<cat key="11" name="Food"/>',
+    '<cat key="12" parent="11" flags="9" name="Grocer" b0="-40"/>',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  const [food, grocer] = parse(xml).categories;
+
+  // A top-level category has no parent, no flags and no budget attributes.
+  assertEquals(food.key, 11);
+  assertEquals(food.parent, 0);
+  assertEquals(food.flags, 0);
+  assertEquals(food.budgets.length, 12);
+
+  assertEquals(grocer.parent, 11);
+  assertEquals(grocer.flags, CATEGORY_FLAG_SUB | CATEGORY_FLAG_BUDGET);
+  assertEquals(grocer.budgets[0], "-40");
+
+  assertEquals(serialize(parse(xml)), xml);
+});
+
+Deno.test("budgets are the b0..b12 attributes: b0 is the every-month amount, b1..b12 the individual months", () => {
+  const xml = [
+    '<?xml version="1.0"?>',
+    '<homebank v="1.3" d="050402">',
+    '<cat key="1" flags="8" name="Heating" b1="-120" b12="-95"/>',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  const [heating] = parse(xml).categories;
+
+  // Slots the XML did not mention are left as holes, not zeroes, so a
+  // category budgeted only in December still reports 13 slots.
+  assertEquals(heating.budgets[1], "-120");
+  assertEquals(heating.budgets[12], "-95");
+  assertEquals(heating.budgets.length, 13);
+  assertEquals(0 in heating.budgets, false);
+});
+
+Deno.test("budgets are renumbered from b0 when serialized, so a gap shifts the months", () => {
+  const xml = [
+    '<?xml version="1.0"?>',
+    '<homebank v="1.3" d="050402">',
+    '<cat key="1" flags="8" name="Heating" b1="-120" b12="-95"/>',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  // The serializer compacts the budget list before numbering it, so b1/b12
+  // come back as b0/b1 and the only case that survives untouched is a
+  // category budgeted from b0 with no gaps. Treated here as a faithful
+  // artifact of the C original (ADR 0001/0003) and asserted as-is.
+  assertEquals(
+    serialize(parse(xml)).split("\n")[2],
+    '<cat key="1" flags="8" name="Heating" b0="-120" b1="-95"/>',
+  );
+});

--- a/packages/@hertzg/xhb/currency.test.ts
+++ b/packages/@hertzg/xhb/currency.test.ts
@@ -1,0 +1,54 @@
+import { assertEquals } from "@std/assert";
+import { parse, serialize } from "./mod.ts";
+import { CURRENCY_FLAG_CUSTOM, serializeCurrency } from "./currency.ts";
+
+Deno.test("parseCurrency reads the formatting rules HomeBank uses to print amounts", () => {
+  const xml = [
+    '<?xml version="1.0"?>',
+    '<homebank v="1.3" d="050402">',
+    '<cur key="3" flags="0" iso="EUR" name="Euro" symb="€" syprf="1" dchar="," gchar=" " frac="2" rate="1.1342000000000001" mdate="0"/>',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  assertEquals(parse(xml).currencies[0], {
+    key: 3,
+    flags: 0,
+    name: "Euro",
+    isoCode: "EUR",
+    symbol: "€",
+    // "€1.00" rather than "1.00 €".
+    symbolIsPrefixed: 1,
+    // European convention: 1 234,56.
+    decimalCharacter: ",",
+    groupingCharacter: " ",
+    fractionDigits: 2,
+    exchangeRate: "1.1342000000000001",
+    lastUpdatedDate: 0,
+  });
+
+  assertEquals(serialize(parse(xml)), xml);
+});
+
+Deno.test("<cur> always writes its full attribute list, zeros and empties included", () => {
+  // Unlike the other entities, currency does not go through hb_xml_tag and
+  // so has no attribute-omission rules at all: a custom currency with no ISO
+  // code and no grouping character still writes iso="" and gchar=""
+  // (this is the Bitcoin entry from the 5.4.2 fixture).
+  assertEquals(
+    serializeCurrency({
+      key: 4,
+      flags: CURRENCY_FLAG_CUSTOM,
+      name: "Bitcoin",
+      isoCode: "",
+      symbol: "₿",
+      symbolIsPrefixed: 0,
+      decimalCharacter: ".",
+      groupingCharacter: "",
+      fractionDigits: 2,
+      exchangeRate: "0.00020000000000000001",
+      lastUpdatedDate: 0,
+    }),
+    '<cur key="4" flags="2" iso="" name="Bitcoin" symb="₿" syprf="0" dchar="." gchar="" frac="2" rate="0.00020000000000000001" mdate="0"/>',
+  );
+});

--- a/packages/@hertzg/xhb/mod.test.ts
+++ b/packages/@hertzg/xhb/mod.test.ts
@@ -1,24 +1,111 @@
-import * as Path from "node:path";
-import * as FS from "node:fs";
-import { dirname, fromFileUrl } from "@std/path";
-import { parse, serialize } from "./mod.ts";
 import { assertEquals } from "@std/assert";
+import { parse, serialize } from "./mod.ts";
 
-const SAVES_DIR = Path.join(
-  dirname(fromFileUrl(import.meta.url)),
-  "./fixtures/saves",
-);
-const SAVES = FS.readdirSync(SAVES_DIR)
-  .filter((name) => name.endsWith(".xhb"))
-  .map((name) => ({
-    name,
-    path: Path.join(SAVES_DIR, name),
-  }));
+const save = (name: string) =>
+  Deno.readTextFileSync(new URL(`./fixtures/saves/${name}`, import.meta.url));
 
-SAVES.forEach(({ name, path }) => {
-  Deno.test(`produces identical output when saving unmodified parsed object for ${name}`, () => {
-    const contents = FS.readFileSync(path, { encoding: "utf8" });
-    const serialized = serialize(parse(contents));
-    assertEquals(serialized, contents);
-  });
+Deno.test("a real HomeBank 5.2.4 save round-trips byte for byte", () => {
+  const original = save("example-v5.2.4.xhb");
+  assertEquals(serialize(parse(original)), original);
+});
+
+Deno.test("a real HomeBank 5.3.1 save round-trips byte for byte", () => {
+  const original = save("example-v5.3.1.xhb");
+  assertEquals(serialize(parse(original)), original);
+});
+
+Deno.test("a real HomeBank 5.4.2 save round-trips byte for byte", () => {
+  const original = save("example-v5.4.2.xhb");
+  assertEquals(serialize(parse(original)), original);
+});
+
+Deno.test("a whole file is a flat list of elements under <homebank>, one array per entity", () => {
+  const xml = [
+    '<?xml version="1.0"?>',
+    '<homebank v="1.3" d="050402">',
+    '<properties title="John Money" curr="1"/>',
+    '<cur key="1" flags="0" iso="GBP" name="Pound Sterling" symb="£" syprf="1" dchar="." gchar="," frac="2" rate="0" mdate="0"/>',
+    '<account key="1" pos="1" type="1" curr="1" name="Cheque Account"/>',
+    '<pay key="1" name="Amazon"/>',
+    '<cat key="1" name="Food"/>',
+    '<tag key="1" name="groceries"/>',
+    '<asg key="1" flags="2" field="1" name="Amazon" payee="1"/>',
+    '<fav key="1" amount="-15" account="1" wording="Donation" nextdate="731961" every="1" unit="2"/>',
+    '<ope date="736968" amount="-42.5" account="1" payee="1" category="1"/>',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  const xhb = parse(xml);
+
+  // Nothing is nested: relationships between entities are integer keys.
+  assertEquals(xhb.properties?.owner, "John Money");
+  assertEquals(xhb.currencies.length, 1);
+  assertEquals(xhb.accounts.length, 1);
+  assertEquals(xhb.payees.length, 1);
+  assertEquals(xhb.categories.length, 1);
+  assertEquals(xhb.tags.length, 1);
+  assertEquals(xhb.assigns.length, 1);
+  assertEquals(xhb.archives.length, 1);
+  assertEquals(xhb.operations.length, 1);
+});
+
+Deno.test("serialize writes entities in HomeBank's order, whatever order they were read in", () => {
+  const shuffled = [
+    '<?xml version="1.0"?>',
+    '<homebank v="1.3" d="050402">',
+    '<ope date="736968" amount="-42.5" account="1"/>',
+    '<tag key="1" name="groceries"/>',
+    '<cat key="1" name="Food"/>',
+    '<pay key="1" name="Amazon"/>',
+    '<account key="1" pos="1" type="1" curr="1" name="Cheque Account"/>',
+    '<cur key="1" flags="0" iso="GBP" name="Pound Sterling" symb="£" syprf="1" dchar="." gchar="," frac="2" rate="0" mdate="0"/>',
+    '<properties title="John Money" curr="1"/>',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  // properties, currencies, accounts, payees, categories, tags, assigns,
+  // archives, operations — the order HomeBank itself writes.
+  assertEquals(
+    serialize(parse(shuffled)),
+    [
+      '<?xml version="1.0"?>',
+      '<homebank v="1.3" d="050402">',
+      // `auto_smode` is one of the few attributes written even at zero.
+      '<properties title="John Money" curr="1" auto_smode="0"/>',
+      '<cur key="1" flags="0" iso="GBP" name="Pound Sterling" symb="£" syprf="1" dchar="." gchar="," frac="2" rate="0" mdate="0"/>',
+      '<account key="1" pos="1" type="1" curr="1" name="Cheque Account"/>',
+      '<pay key="1" name="Amazon"/>',
+      '<cat key="1" name="Food"/>',
+      '<tag key="1" name="groceries"/>',
+      '<ope date="736968" amount="-42.5" account="1"/>',
+      "</homebank>",
+      "",
+    ].join("\n"),
+  );
+});
+
+Deno.test("elements the format does not define are dropped, as is a missing <properties>", () => {
+  const xml = [
+    '<?xml version="1.0"?>',
+    '<homebank v="1.3" d="050402">',
+    '<future-entity key="1" name="from a newer HomeBank"/>',
+    '<pay key="1" name="Amazon"/>',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  // The library round-trips what it understands and nothing else, so an
+  // unknown element is lost rather than preserved.
+  assertEquals(
+    serialize(parse(xml)),
+    [
+      '<?xml version="1.0"?>',
+      '<homebank v="1.3" d="050402">',
+      '<pay key="1" name="Amazon"/>',
+      "</homebank>",
+      "",
+    ].join("\n"),
+  );
 });

--- a/packages/@hertzg/xhb/operation.test.ts
+++ b/packages/@hertzg/xhb/operation.test.ts
@@ -1,0 +1,129 @@
+import { assertEquals } from "@std/assert";
+import { parse, serialize } from "./mod.ts";
+import {
+  OPERATION_FLAG_SPLIT,
+  PAY_MODE_CCARD,
+  serializeOperation,
+} from "./operation.ts";
+
+// HomeBank omits an attribute instead of writing an empty one, so a parsed
+// entity holds `undefined` wherever the XML had nothing.
+const OMITTED = undefined as unknown as string;
+
+Deno.test("an <ope> is one transaction: a date, an amount and a pile of foreign keys", () => {
+  const xml = [
+    '<?xml version="1.0"?>',
+    '<homebank v="1.3" d="050402">',
+    '<ope date="736968" amount="-42.5" account="1" paymode="1" payee="1" category="1" wording="Weekly shop" info="ref-1" kxfer="3"/>',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  assertEquals(parse(xml).operations[0], {
+    // Dates are Julian day numbers, not timestamps.
+    date: 736968,
+    amount: "-42.5",
+    account: 1,
+    // `dst_account`, `st` and `flags` were omitted, so they are 0.
+    destinationAccount: 0,
+    payMode: PAY_MODE_CCARD,
+    status: 0,
+    flags: 0,
+    payee: 1,
+    category: 1,
+    // `wording` in the XML, `memo` on the object.
+    memo: "Weekly shop",
+    info: "ref-1",
+    tags: [],
+    // Both halves of an internal transfer carry the same kxfer.
+    kxfer: 3,
+    splits: [],
+  });
+
+  assertEquals(serialize(parse(xml)), xml);
+});
+
+Deno.test("tags are a space-separated list of tag names, not keys", () => {
+  const xml = [
+    '<?xml version="1.0"?>',
+    '<homebank v="1.3" d="050402">',
+    '<tag key="1" name="groceries"/>',
+    '<tag key="2" name="weekly"/>',
+    '<ope date="736968" amount="-42.5" account="1" tags="groceries weekly"/>',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  assertEquals(parse(xml).operations[0].tags, ["groceries", "weekly"]);
+
+  // Which is why a tag name can never contain a space.
+  assertEquals(serialize(parse(xml)), xml);
+});
+
+Deno.test("a split transaction stores its parts in three parallel ||-separated lists", () => {
+  const xml = [
+    '<?xml version="1.0"?>',
+    '<homebank v="1.3" d="050402">',
+    '<ope date="736968" amount="-20" account="1" flags="256" scat="12||13" samt="-15.5||-4.5" smem="bread||"/>',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  const [operation] = parse(xml).operations;
+
+  // scat/samt/smem are zipped positionally; the second split simply has an
+  // empty memo, which still occupies its slot in `smem`.
+  assertEquals(operation.splits, [
+    { category: 12, amount: "-15.5", memo: "bread" },
+    { category: 13, amount: "-4.5", memo: "" },
+  ]);
+
+  // The whole-transaction amount stays alongside the split amounts.
+  assertEquals(operation.amount, "-20");
+
+  assertEquals(serialize(parse(xml)), xml);
+});
+
+Deno.test("parsing splits sets OPERATION_FLAG_SPLIT even when the flags attribute did not", () => {
+  const xml = [
+    '<?xml version="1.0"?>',
+    '<homebank v="1.3" d="050402">',
+    '<ope date="736968" amount="-20" account="1" scat="12||13" samt="-15.5||-4.5" smem="||"/>',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  const [operation] = parse(xml).operations;
+
+  assertEquals(operation.flags, OPERATION_FLAG_SPLIT);
+  assertEquals(operation.splits.length, 2);
+
+  // The flag is therefore added to the output that was missing from the
+  // input — the one case where parse/serialize is allowed to be additive.
+  assertEquals(
+    serialize(parse(xml)).split("\n")[2],
+    '<ope date="736968" amount="-20" account="1" flags="256" scat="12||13" samt="-15.5||-4.5" smem="||"/>',
+  );
+});
+
+Deno.test("serializeOperation writes the amount even at zero but drops zeroed keys", () => {
+  assertEquals(
+    serializeOperation({
+      date: 736968,
+      amount: "0",
+      account: 1,
+      destinationAccount: 0,
+      payMode: 0,
+      status: 0,
+      flags: 0,
+      payee: 0,
+      category: 0,
+      memo: OMITTED,
+      info: OMITTED,
+      tags: [],
+      kxfer: 0,
+      splits: [],
+    }),
+    '<ope date="736968" amount="0" account="1"/>',
+  );
+});

--- a/packages/@hertzg/xhb/versions.test.ts
+++ b/packages/@hertzg/xhb/versions.test.ts
@@ -1,0 +1,28 @@
+import { assertEquals } from "@std/assert";
+import { parse } from "./mod.ts";
+import { serializeVersions } from "./versions.ts";
+
+Deno.test("the <homebank> root carries the file format version and the app data version", () => {
+  const xml = [
+    '<?xml version="1.0"?>',
+    '<homebank v="1.3999999999999999" d="050402">',
+    "</homebank>",
+    "",
+  ].join("\n");
+
+  // `v` is a C double written at full precision, so it is kept as text
+  // (ADR 0002). `d` is the HomeBank release that wrote the file, here 5.4.2.
+  assertEquals(parse(xml).versions, {
+    file: "1.3999999999999999",
+    data: 50402,
+  });
+});
+
+Deno.test("the data version is written back zero-padded to six digits", () => {
+  // 50402 must not come back out as d="50402" — this is the one place where
+  // a number is reformatted on the way out (ADR 0001).
+  assertEquals(
+    serializeVersions({ file: "1.3999999999999999", data: 50402 }),
+    '<homebank v="1.3999999999999999" d="050402">',
+  );
+});


### PR DESCRIPTION
Takes `@hertzg/xhb` from a single 24-line `mod.test.ts` (three fixture round-trips, one assertion) to 43 tests across ten files. No source files touched.

## Shape

One test file per module, mirroring ADR 0003's layout. Every test carries its own literal XML document and its own expected output — no shared helpers, no generated cases, no setup pyramids. The intent is that the suite reads top to bottom as a description of the XHB format, so it doubles as the reference the package doesn't otherwise have.

`mod.test.ts` keeps the three fixture round-trips but spells them out as named tests rather than a `readdirSync` loop, and drops the `node:fs` / `node:path` mix for `Deno.readTextFileSync(new URL(...))`.

## What's covered

- **Primitives** — `atoi`'s missing (`0`) vs present-but-malformed (`NaN`) split, which is the concrete mechanism behind ADR 0001's "missing attributes parse to 0"; `parseGDouble` preserving `"76.219999999999999"`; `parseGCharP` distinguishing `""` from `undefined`, which is what decides whether an attribute gets written back.
- **Attribute omission rules** — `hb_xml_attr_int` (drops 0) vs `int0` (keeps it) vs `amt` (amounts are text, so `minimum="0"` survives) vs `txt` (drops only `undefined`). These are the core of byte fidelity.
- **`hb_escape_text`** — the five metacharacters, the numeric-entity ranges, and explicitly that tab (0x09) and NEL (0x85) fall in the gaps and are *not* escaped.
- **The `||` split framing**, including that an empty memo still occupies its slot, and that `OPERATION_FLAG_SPLIT` is OR-ed in at parse time even when `flags` omitted it.
- **Entity mapping** as whole-object `assertEquals`, so attribute→property renames (`wording`→`memo`, `initial`→`startingBalance`) are visible side by side.
- **Assign's pre-0.8 migration**, including that it overwrites an existing `flags` attribute on a v0.7 file.
- **Document level** — the fixed write order regardless of read order, unknown elements being dropped, `d="050402"` re-padding.

## The three known quirks

Asserted as current behaviour with a comment each, not fixed, per your call that they're C artifacts. One correction to that, though — the agent came back fairly confident that two of them are transcription slips rather than faithful ports, so recording the reasoning here rather than burying it:

- **Sparse budget re-indexing** (`category.ts:60-67`). In C the budget table is a dense `gdouble[13]` and the save loop is `for(j=0;j<=12;j++) if(budget[j]) … "b%d", j` — the index is the loop counter and cannot shift. The JS builds a sparse array and then `.filter().map((v, i) => …)`, and `filter` skips holes, so survivors are renumbered from 0. A December-only budget round-trips as January. The fixtures don't catch it because all three only use `b0`.
- **`.replace("|", "")`** (`_serialize.ts:175`) hits only the first occurrence; every plausible C equivalent removes all of them. A memo with two pipes keeps the second — which is precisely the character the `||` framing can't tolerate, so the guard doesn't guard. Lower confidence, HomeBank's exact line wasn't located.
- **notes-only escaping** — this one does look faithful: HomeBank has `hb_xml_append_txt` (raw) and `hb_xml_append_txt_crlf` (escaped), and only `<account notes>` uses the latter.

Happy to open a follow-up for either of the first two; they're behavioural fixes and would need `fix(@hertzg/xhb)` with a round-trip caveat.

## Other findings

- `<cur>` and `<tag>` bypass `hb_xml_tag` entirely — hand-written template strings with a fixed attribute list, so they have *no* omission rules. Undocumented and easy to trip over when adding an entity.
- `parse → serialize` on a file from a newer HomeBank is lossy (unknown elements dropped). ADR 0001 reads as though everything is preserved.
- `atoi("")` is `NaN`, so a present-but-empty integer attribute serialises as `key="NaN"` — the one input shape that corrupts output rather than throwing.

## Notes

- `deno task lint` and `deno task test` pass from the repo root.
- Deliberately does not test `ParseOptions.onEntity` / `onUnknownNode` — removed in #183 — so the two branches don't conflict.
- No JSDoc `@example` blocks; ADR 0007 compliance is a separate piece of work.