### PR TITLE
fix: stop docs workflow failing when a PR is merged

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,29 +13,26 @@ permissions:
 
 jobs:
   docs:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout
-        if: github.event.action != 'closed'
         uses: actions/checkout@v7
 
       - name: Set up Deno
-        if: github.event.action != 'closed'
         uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 
       - name: Cache dependencies
-        if: github.event.action != 'closed'
         run: deno install
 
       - name: Generate docs
-        if: github.event.action != 'closed'
         run: deno run --allow-read --allow-write --allow-run _tools/gen_docs.ts docs
 
       - name: Deploy main
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docs
@@ -43,23 +40,35 @@ jobs:
           clean-exclude: pr/
 
       - name: Deploy PR preview
-        if: github.event_name == 'pull_request' && github.event.action != 'closed'
+        if: github.event_name == 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docs
           target-folder: pr/${{ github.event.pull_request.number }}
 
       - name: Comment on PR
-        if: github.event_name == 'pull_request' && github.event.action != 'closed'
+        if: github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: docs-preview
           message: |
             **Docs preview:** https://hertzg.github.io/jsr-monorepo/pr/${{ github.event.pull_request.number }}/
 
+  remove-preview:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Create empty folder
+        run: mkdir -p .preview-empty
+
       - name: Remove PR preview
-        if: github.event_name == 'pull_request' && github.event.action == 'closed'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: /tmp/empty
+          folder: .preview-empty
           target-folder: pr/${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Root cause

The `docs` workflow fails on **every merged PR**. It is not the `main` deployment that
breaks — the `push` run on `main` succeeds. The failure is the second run that fires at
the same instant: the `pull_request` run for the `closed` event.

GitHub sets `github.ref` differently depending on how a PR is closed:

- closed **without** merging → `refs/pull/<n>/merge`
- closed **by merging** → the fully qualified base branch ref, i.e. `refs/heads/main`

The `Deploy main` step was gated on `if: github.ref == 'refs/heads/main'` alone, so on a
merged-PR `closed` event it evaluated **true** and ran — while `Checkout`, `Set up Deno`,
`Cache dependencies` and `Generate docs` were all skipped by
`if: github.event.action != 'closed'`. The deploy action was therefore pointed at a `docs`
folder that was never generated.

## Evidence

Failing run `30722906404` (event `pull_request`, branch `chore/xhb-tests`, PR #185, fired at
`23:13:25Z` — the merge moment):

```
Set up job          success
Checkout            skipped
Set up Deno         skipped
Cache dependencies  skipped
Generate docs       skipped
Deploy main         failure   <-- ran despite being a PR event
Deploy PR preview   skipped
Comment on PR       skipped
Remove PR preview   skipped
```

```
##[error]The directory you're trying to deploy named
/home/runner/work/jsr-monorepo/jsr-monorepo/docs doesn't exist.
Please double check the path and any prerequisite build scripts and try again.
```

Identical failure and identical step pattern in `30723392725` (PR #184), `27823861731`
(PR #180), `27781178185` (PR #179), `25285606835` (PR #178), `25284627859` (PR #177) — one
per merged PR, going back to `024bd5f` where the workflow was introduced.

Contrast with an **open**-PR run, `25171571158` (`feat/binstruct-bencode`): there
`github.ref` is `refs/pull/156/merge`, `Deploy main` is correctly **skipped**, and the build
and preview steps run. That is the whole behavioural diff.

The corresponding `push` runs on `main` (`30722906288`, `30723392593`, `30089528397`, …) are
all **green**, so the `main` docs deployment itself was never broken.

## Second, hidden bug

Because `Deploy main` failed first, `Remove PR preview` was skipped on every single closed
PR and has therefore **never once run**. `gh-pages` currently holds 51 stale preview
directories under `pr/` (`135` … `186`). Fixing only the condition above would have made
that step start running and immediately fail, for two reasons:

- `folder: /tmp/empty` — nothing in the workflow ever created that directory, and the deploy
  action errors on a missing folder (same error as above).
- `Checkout` was skipped on `closed` events, so there was no git working tree; the deploy
  action needs one (it uses `git worktree add` against `.git`).

## Fix

Split the two paths into separate jobs so their conditions cannot overlap:

- `docs` job — `if: github.event.action != 'closed'`, which removes the four repeated
  per-step conditions.
- `Deploy main` — now `github.event_name != 'pull_request' && github.ref == 'refs/heads/main'`,
  so it can only fire on `push`/`workflow_dispatch` regardless of what `github.ref` is set to.
- `remove-preview` job — `if: github.event_name == 'pull_request' && github.event.action == 'closed'`,
  with a real checkout (`ref: base.ref`, valid whether or not the PR was merged) and an
  empty folder it actually creates.

## Repository settings

None required. Pages is already configured correctly for this workflow:

```
gh api repos/hertzg/jsr-monorepo/pages
{"status":"built","build_type":"legacy","source":{"branch":"gh-pages","path":"/"}, ...}
```

`build_type: legacy` with source branch `gh-pages` is exactly what
`JamesIves/github-pages-deploy-action` targets, so there is no `github-pages`
environment, no `pages: write` / `id-token: write` requirement, and no deployment branch
protection in play. The fix is complete as code.

## Follow-ups (not in this PR)

- The 51 stale `pr/*` directories already on `gh-pages` are not cleaned up retroactively;
  they need a one-off manual prune.
- On a merge, the `push` deploy and the `remove-preview` job both push to `gh-pages`
  concurrently. Both use `JamesIves/github-pages-deploy-action` with its default
  `attempt-limit: 3` retry, and they touch disjoint paths (`clean-exclude: pr/`), so this
  should self-resolve — but a `concurrency` group on `gh-pages` would make it deterministic.

## Verification

- `deno task lint` — pass
- `deno task test` — pass
- `actionlint .github/workflows/docs.yaml` — clean
- `_tools/gen_docs.ts` run locally — generates all 24 package doc trees plus `index.html`
