### PR TITLE
chore: regenerate deps snapshots on renovate branches

### DIFF
--- a/.github/workflows/renovate-snapshots.yaml
+++ b/.github/workflows/renovate-snapshots.yaml
@@ -1,0 +1,60 @@
+# Regenerates `_deps.snap` on Renovate branches that change `import_map.json`.
+#
+# Renovate edits only the import map, which belongs to no package. The
+# snapshots are what place a dependency bump inside `packages/<scope>/<name>/`,
+# which is how Release Please attributes it — so without them the bump both
+# fails `lint:deps` and can never be released (ADR 0005).
+#
+# Renovate cannot do this itself: `postUpgradeTasks` on the Mend-hosted app
+# only permits an allowlist that cannot run arbitrary commands.
+name: renovate-snapshots
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - import_map.json
+
+permissions:
+  contents: read
+
+concurrency:
+  group: renovate-snapshots-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  update:
+    if: >-
+      startsWith(github.head_ref, 'renovate/') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # A GitHub App token, not GITHUB_TOKEN: pushes made with the default
+      # token do not trigger further workflow runs, which would leave the
+      # PR's checks red against the pre-fix commit.
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: denoland/setup-deno@v2
+
+      - run: deno run -A _tools/check_deps.ts --update
+
+      # Nothing to commit on a re-run, which is what terminates the loop:
+      # this workflow triggers on its own push, finds no diff, and stops.
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A -- '*_deps.snap'
+          git diff --staged --quiet || {
+            git commit -m "chore: update dependency snapshots"
+            git push
+          }

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "extends": [":semanticCommits"],
   "assigneesFromCodeOwners": true,
   "minimumReleaseAge": "3 days",
+  "gitIgnoredAuthors": [
+    "41898282+github-actions[bot]@users.noreply.github.com"
+  ],
   "packageRules": [
     {
       "matchPackagePatterns": ["^@hertzg/", "^@binstruct/"],


### PR DESCRIPTION
Stacked on #184 — both touch `renovate.json`, so this targets that branch and will retarget to `main` once #184 merges.

## Why not just have Renovate do it

That was the first thing checked. `postUpgradeTasks` exists on the Mend-hosted app, but runs against an allowlist you don't control. Yours is:

```json
"allowedCommands": [
  "^git add --all$",
  "^git reset$",
  "^pwd$"
]
```

Those can stage files, but nothing there can *modify* one — so there is no way to invoke `check_deps.ts --update` from Renovate. Self-hosting Renovate would lift the restriction, which is a much larger change than this workflow.

## What this fixes

Renovate edits exactly one file, root `import_map.json`. Two things follow:

1. `lint:deps` fails, because the snapshots still name the old version.
2. More seriously, the PR contains **no file inside any package directory**. Release Please attributes commits by path, so a dependency bump with stale snapshots is unreleasable — see #184 and ADR 0005.

Both were being cleared by hand on every dependency PR. This workflow runs `deno run -A _tools/check_deps.ts --update` on `renovate/*` branches that touch `import_map.json` and pushes the result to the PR.

Worth noting it makes the review *better*, not just quieter: the affected-package list now arrives as a commit in the PR diff, which is exactly the thing you want to see before merging, rather than something you reconstruct from a red log.

## The three things that make this work

- **App token, not `GITHUB_TOKEN`.** Pushes made with the default token do not trigger further workflow runs, so the PR's checks would stay red against the pre-fix commit. Uses `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`, the same pattern as `release-please.yaml:17-21` — which already pushes to bot branches this way.
- **`gitIgnoredAuthors`.** Not optional. Without it Renovate sees a foreign commit on its branch, marks the PR as edited and silently stops rebasing — which would quietly freeze the `all-minor-patch` group PR. The address matches what the workflow commits as, byte for byte.
- **Loop termination** via `git diff --staged --quiet`. The bot's own push re-triggers the workflow, `--update` is a no-op the second time, nothing is pushed. Deliberately *not* gated on `github.actor == 'renovate[bot]'`, since after the fixup push the actor is the App and that would break the re-run this depends on.

## Scope guards

- `paths: [import_map.json]` — GitHub Actions-only Renovate PRs don't touch dependency snapshots and don't run this.
- `if:` requires both a `renovate/` head branch and a same-repo PR. Fork PRs can't reach the secrets anyway; the explicit condition just makes it fail clearly rather than confusingly.
- `permissions: contents: read` at workflow level. The write happens through the App token, not the job's own token.

## Verified

- `renovate.json` validated against Renovate's published schema (`gitIgnoredAuthors` is `array<string>`, RFC5322 addresses).
- Workflow YAML parses; `if:` condition resolves as intended.
- `deno task lint` and `deno task test` pass from the repo root.

The one thing that cannot be verified before merge is the App token push actually re-triggering checks. If it doesn't, the symptom is a green fixup job with the PR's other checks still red on the old SHA, and the fix is a dedicated App or PAT instead of the release App's credentials.