### PR TITLE
chore: exclude agent worktrees from workspace globs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -10,7 +10,7 @@
     },
     "test:parallel": "deno task test:sequential -- --parallel",
     "test:sequential": "deno test --allow-all --coverage --clean",
-    "test:doc": "deno test --allow-all --coverage --clean --doc --ignore=\"**/*.test.ts,**/adr/**\"",
+    "test:doc": "deno test --allow-all --coverage --clean --doc --ignore=\"**/*.test.ts,**/adr/**,.claude/**\"",
     "lint": {
       "dependencies": [
         "lint:deno",
@@ -34,6 +34,7 @@
   },
   "exclude": [
     ".git",
+    ".claude",
     "cov",
     "coverage",
     "docs",


### PR DESCRIPTION
`deno task test` currently fails in any checkout that has agent worktrees under `.claude/worktrees/` — Deno's workspace glob expands into them and type-checks every worktree's copy of every package.

Two changes, because they are not redundant:

- `exclude`: add `.claude` — covers `lint`, `test:parallel`, `test:sequential`
- `test:doc`: repeat `.claude/**` in `--ignore` — passing `--ignore` on the CLI **replaces** the config `exclude` rather than adding to it, so the task needs its own copy

Found while adding a new package: the full suite failed with errors pointing at `.claude/worktrees/agent-*/packages/@binstruct/png/...`, none of which were in the working tree.

No package files touched, so Release Please will not attribute this to any package.