### PR TITLE
feat(@binstruct/inet)!: wire protocol packages into the inet encapsulation stack

### DIFF
--- a/packages/@binstruct/inet/_deps.snap
+++ b/packages/@binstruct/inet/_deps.snap
@@ -3,11 +3,21 @@
   "deps": {
     ".": [
       "@binstruct/arp",
+      "@binstruct/bfd",
+      "@binstruct/esp",
       "@binstruct/ethernet",
       "@binstruct/icmp",
+      "@binstruct/icmpv6",
+      "@binstruct/igmp",
       "@binstruct/ipv4",
+      "@binstruct/ipv6",
+      "@binstruct/ntp",
+      "@binstruct/pppoe",
+      "@binstruct/sll",
       "@binstruct/tcp",
       "@binstruct/udp",
+      "@binstruct/vlan",
+      "@binstruct/vxlan",
       "@hertzg/binstruct"
     ]
   }

--- a/packages/@binstruct/inet/mod.test.ts
+++ b/packages/@binstruct/inet/mod.test.ts
@@ -2,13 +2,47 @@ import { assert, assertEquals } from "@std/assert";
 import { parseIpv4 } from "@hertzg/ip/ipv4";
 import { ARP_OPCODE, ETHERTYPE_ARP } from "@binstruct/arp";
 import { ETHERTYPE_IPV4 } from "@binstruct/ipv4";
+import { ETHERTYPE_IPV6 } from "@binstruct/ipv6";
 import { IP_PROTOCOL_ICMP } from "@binstruct/icmp";
+import { ICMPV6_TYPE, IP_PROTOCOL_ICMPV6 } from "@binstruct/icmpv6";
+import { IGMP_TYPE, IP_PROTOCOL_IGMP } from "@binstruct/igmp";
+import { IP_PROTOCOL_ESP } from "@binstruct/esp";
 import { IP_PROTOCOL_TCP } from "@binstruct/tcp";
-import { IP_PROTOCOL_UDP } from "@binstruct/udp";
+import { IP_PROTOCOL_UDP, type UdpPacket } from "@binstruct/udp";
+import { TPID_8021Q } from "@binstruct/vlan";
+import { ETHERTYPE_PPPOE_SESSION, PPPOE_CODE } from "@binstruct/pppoe";
+import {
+  VXLAN_FLAG_VALID_VNI,
+  VXLAN_HEADER_SIZE,
+  VXLAN_PORT,
+} from "@binstruct/vxlan";
+import { NTP_MODE, NTP_PACKET_SIZE, NTP_PORT } from "@binstruct/ntp";
+import { BFD_CONTROL_SIZE, BFD_PORT, BFD_STATE } from "@binstruct/bfd";
+import { SLL_PACKET_TYPE } from "@binstruct/sll";
 import {
   type FrameRefined,
   inetFrame,
   internetChecksum,
+  type Ipv4EspPacket,
+  type Ipv4Frame,
+  type Ipv4IgmpPacket,
+  type Ipv4TcpPacket,
+  type Ipv4UdpPacket,
+  type Ipv6Icmpv6Packet,
+  type Ipv6Refined,
+  type Ipv6TcpPacket,
+  type Ipv6UdpPacket,
+  type PppoeIpv4Frame,
+  type PppoeIpv6Frame,
+  type PppoeSessionPacket,
+  type SllFrameRefined,
+  sllInetFrame,
+  type UdpBfdPacket,
+  type UdpNtpPacket,
+  type UdpRefined,
+  type UdpVxlanPacket,
+  type VlanIpv4Frame,
+  type VlanQinQFrame,
 } from "./mod.ts";
 
 Deno.test("internetChecksum: RFC 1071 §3 worked example", () => {
@@ -160,7 +194,7 @@ Deno.test("inetFrame: round-trips ethernet → ipv4 → tcp", () => {
   assert("protocol" in decoded.payload);
   assertEquals(decoded.payload.protocol, IP_PROTOCOL_TCP);
   assert(!(decoded.payload.payload instanceof Uint8Array));
-  assert("sequenceNumber" in decoded.payload.payload);
+  assert("dataOffsetReserved" in decoded.payload.payload);
   assertEquals(decoded.payload.payload.sourcePort, 49152);
   assertEquals(decoded.payload.payload.destinationPort, 80);
   assertEquals(decoded.payload.payload.sequenceNumber, 0xdeadbeef);
@@ -286,7 +320,7 @@ Deno.test("inetFrame: unknown IPv4 protocol surfaces as a raw Uint8Array", () =>
         fragmentOffset: 0,
       },
       timeToLive: 64,
-      protocol: 50, // ESP — no coder for it in the family yet.
+      protocol: 253, // Reserved for experimentation (RFC 3692) — no coder for it.
       headerChecksum: 0,
       sourceAddress: parseIpv4("10.0.0.1"),
       destinationAddress: parseIpv4("10.0.0.2"),
@@ -304,4 +338,878 @@ Deno.test("inetFrame: unknown IPv4 protocol surfaces as a raw Uint8Array", () =>
   assert("protocol" in decoded.payload);
   assert(decoded.payload.payload instanceof Uint8Array);
   assertEquals(decoded.payload.payload, innerBytes);
+});
+
+Deno.test("inetFrame: round-trips ethernet → vlan → ipv4 → udp", () => {
+  const coder = inetFrame();
+  const udpPayload = new Uint8Array([0xaa, 0xbb]);
+  const value: FrameRefined = {
+    dstMac: new Uint8Array([0, 0, 0, 0, 0, 1]),
+    srcMac: new Uint8Array([0, 0, 0, 0, 0, 2]),
+    etherType: TPID_8021Q,
+    payload: {
+      tci: { pcp: 0, dei: 0, vlanId: 100 },
+      etherType: ETHERTYPE_IPV4,
+      payload: {
+        versionIhl: { version: 4, ihl: 5 },
+        typeOfService: 0,
+        totalLength: 20 + 8 + udpPayload.length,
+        identification: 0,
+        flagsFragmentOffset: {
+          reserved: 0,
+          dontFragment: 0,
+          moreFragments: 0,
+          fragmentOffset: 0,
+        },
+        timeToLive: 64,
+        protocol: IP_PROTOCOL_UDP,
+        headerChecksum: 0,
+        sourceAddress: parseIpv4("10.0.0.1"),
+        destinationAddress: parseIpv4("10.0.0.2"),
+        options: new Uint8Array(0),
+        payload: {
+          srcPort: 1111,
+          dstPort: 2222,
+          length: 8 + udpPayload.length,
+          checksum: 0,
+          payload: udpPayload,
+        },
+      },
+    },
+  };
+
+  const buf = new Uint8Array(128);
+  const written = coder.encode(value, buf);
+  const [decoded, read] = coder.decode(buf.subarray(0, written));
+
+  assertEquals(read, written);
+  const vlanFrame = decoded.payload as VlanIpv4Frame;
+  assertEquals(vlanFrame.tci.vlanId, 100);
+  const ip = vlanFrame.payload;
+  assertEquals(ip.protocol, IP_PROTOCOL_UDP);
+  const udp = ip.payload as UdpPacket;
+  assertEquals(udp.srcPort, 1111);
+  assertEquals(udp.payload, udpPayload);
+});
+
+Deno.test("inetFrame: round-trips ethernet → vlan → vlan → ipv4 (QinQ)", () => {
+  const coder = inetFrame();
+  const value: FrameRefined = {
+    dstMac: new Uint8Array([0, 0, 0, 0, 0, 1]),
+    srcMac: new Uint8Array([0, 0, 0, 0, 0, 2]),
+    etherType: TPID_8021Q,
+    payload: {
+      tci: { pcp: 0, dei: 0, vlanId: 10 }, // outer (service) tag
+      etherType: TPID_8021Q,
+      payload: {
+        tci: { pcp: 0, dei: 0, vlanId: 20 }, // inner (customer) tag
+        etherType: ETHERTYPE_IPV4,
+        payload: {
+          versionIhl: { version: 4, ihl: 5 },
+          typeOfService: 0,
+          totalLength: 20,
+          identification: 0,
+          flagsFragmentOffset: {
+            reserved: 0,
+            dontFragment: 0,
+            moreFragments: 0,
+            fragmentOffset: 0,
+          },
+          timeToLive: 64,
+          protocol: 253, // reserved for experimentation — no coder for it
+          headerChecksum: 0,
+          sourceAddress: parseIpv4("10.0.0.1"),
+          destinationAddress: parseIpv4("10.0.0.2"),
+          options: new Uint8Array(0),
+          payload: new Uint8Array(0),
+        },
+      },
+    },
+  };
+
+  const buf = new Uint8Array(128);
+  const written = coder.encode(value, buf);
+  const [decoded, read] = coder.decode(buf.subarray(0, written));
+
+  assertEquals(read, written);
+  const outer = decoded.payload as VlanQinQFrame;
+  assertEquals(outer.tci.vlanId, 10);
+  const inner = outer.payload as VlanIpv4Frame;
+  assertEquals(inner.tci.vlanId, 20);
+  assertEquals(inner.payload.protocol, 253);
+});
+
+Deno.test("inetFrame: a third stacked VLAN tag decodes raw (QinQ depth is bounded)", () => {
+  const coder = inetFrame();
+  const value: FrameRefined = {
+    dstMac: new Uint8Array([0, 0, 0, 0, 0, 1]),
+    srcMac: new Uint8Array([0, 0, 0, 0, 0, 2]),
+    etherType: TPID_8021Q,
+    payload: {
+      tci: { pcp: 0, dei: 0, vlanId: 10 },
+      etherType: TPID_8021Q,
+      payload: {
+        tci: { pcp: 0, dei: 0, vlanId: 20 },
+        // A third 0x8100 EtherType — depth is already exhausted at this
+        // level, so this tag's payload stays raw bytes rather than being
+        // parsed as yet another VlanTag.
+        etherType: TPID_8021Q,
+        payload: new Uint8Array([0x11, 0x22, 0x33, 0x44]),
+      },
+    },
+  };
+
+  const buf = new Uint8Array(64);
+  const written = coder.encode(value, buf);
+  const [decoded] = coder.decode(buf.subarray(0, written));
+
+  const outer = decoded.payload as VlanQinQFrame;
+  const middle = outer.payload;
+  // The third tag is never unwrapped — it stays a raw VlanTag whose
+  // payload is the undecoded bytes, proving the QinQ depth bound.
+  assert(middle.payload instanceof Uint8Array);
+  assertEquals(middle.payload, new Uint8Array([0x11, 0x22, 0x33, 0x44]));
+});
+
+Deno.test("inetFrame: round-trips ethernet → pppoe-session → ppp(ipv4) → tcp", () => {
+  const coder = inetFrame();
+  const tcpPayload = new Uint8Array([0x68, 0x69]);
+  const ipv4TotalLength = 20 + 20 + tcpPayload.length;
+  const value: FrameRefined = {
+    dstMac: new Uint8Array([0, 0, 0, 0, 0, 1]),
+    srcMac: new Uint8Array([0, 0, 0, 0, 0, 2]),
+    etherType: ETHERTYPE_PPPOE_SESSION,
+    payload: {
+      versionType: { version: 1, type: 1 },
+      code: PPPOE_CODE.SESSION_DATA,
+      sessionId: 0x1234,
+      // The PPP protocol ID (2 bytes) is inside PPPoE's payload, so it
+      // counts toward `length` in addition to the IPv4 datagram.
+      length: 2 + ipv4TotalLength,
+      payload: {
+        pppProtocol: 0x0021,
+        payload: {
+          versionIhl: { version: 4, ihl: 5 },
+          typeOfService: 0,
+          totalLength: ipv4TotalLength,
+          identification: 0,
+          flagsFragmentOffset: {
+            reserved: 0,
+            dontFragment: 0,
+            moreFragments: 0,
+            fragmentOffset: 0,
+          },
+          timeToLive: 64,
+          protocol: IP_PROTOCOL_TCP,
+          headerChecksum: 0,
+          sourceAddress: parseIpv4("192.0.2.1"),
+          destinationAddress: parseIpv4("192.0.2.2"),
+          options: new Uint8Array(0),
+          payload: {
+            sourcePort: 49152,
+            destinationPort: 80,
+            sequenceNumber: 1,
+            acknowledgmentNumber: 0,
+            dataOffsetReserved: { dataOffset: 5, reserved: 0 },
+            flags: {
+              cwr: 0,
+              ece: 0,
+              urg: 0,
+              ack: 0,
+              psh: 0,
+              rst: 0,
+              syn: 1,
+              fin: 0,
+            },
+            window: 65535,
+            checksum: 0,
+            urgentPointer: 0,
+            options: new Uint8Array(0),
+            payload: tcpPayload,
+          },
+        },
+      },
+    },
+  };
+
+  const buf = new Uint8Array(128);
+  const written = coder.encode(value, buf);
+  const [decoded, read] = coder.decode(buf.subarray(0, written));
+
+  assertEquals(read, written);
+  const session = decoded.payload as PppoeSessionPacket;
+  assertEquals(session.sessionId, 0x1234);
+  const ppp = session.payload as PppoeIpv4Frame;
+  assertEquals(ppp.pppProtocol, 0x0021);
+  const ip = ppp.payload as Ipv4TcpPacket;
+  assertEquals(ip.payload.sourcePort, 49152);
+  assertEquals(ip.payload.payload, tcpPayload);
+});
+
+Deno.test("inetFrame: round-trips ethernet → pppoe-session → ppp(ipv6) → tcp", () => {
+  const coder = inetFrame();
+  const tcpPayload = new Uint8Array([0x68, 0x69]);
+  const tcpTotalLength = 20 + tcpPayload.length;
+  const value: FrameRefined = {
+    dstMac: new Uint8Array([0, 0, 0, 0, 0, 1]),
+    srcMac: new Uint8Array([0, 0, 0, 0, 0, 2]),
+    etherType: ETHERTYPE_PPPOE_SESSION,
+    payload: {
+      versionType: { version: 1, type: 1 },
+      code: PPPOE_CODE.SESSION_DATA,
+      sessionId: 0x5678,
+      length: 2 + 40 + tcpTotalLength,
+      payload: {
+        pppProtocol: 0x0057,
+        payload: {
+          versionClassFlow: { version: 6, trafficClass: 0, flowLabel: 0 },
+          payloadLength: tcpTotalLength,
+          nextHeader: IP_PROTOCOL_TCP,
+          hopLimit: 64,
+          sourceAddress: new Uint8Array(16).fill(0x11),
+          destinationAddress: new Uint8Array(16).fill(0x22),
+          payload: {
+            sourcePort: 49152,
+            destinationPort: 80,
+            sequenceNumber: 1,
+            acknowledgmentNumber: 0,
+            dataOffsetReserved: { dataOffset: 5, reserved: 0 },
+            flags: {
+              cwr: 0,
+              ece: 0,
+              urg: 0,
+              ack: 0,
+              psh: 0,
+              rst: 0,
+              syn: 1,
+              fin: 0,
+            },
+            window: 65535,
+            checksum: 0,
+            urgentPointer: 0,
+            options: new Uint8Array(0),
+            payload: tcpPayload,
+          },
+        },
+      },
+    },
+  };
+
+  const buf = new Uint8Array(128);
+  const written = coder.encode(value, buf);
+  const [decoded, read] = coder.decode(buf.subarray(0, written));
+
+  assertEquals(read, written);
+  const session = decoded.payload as PppoeSessionPacket;
+  const ppp = session.payload as PppoeIpv6Frame;
+  assertEquals(ppp.pppProtocol, 0x0057);
+  const ip = ppp.payload as Ipv6TcpPacket;
+  assertEquals(ip.nextHeader, IP_PROTOCOL_TCP);
+  assertEquals(ip.payload.sourcePort, 49152);
+  assertEquals(ip.payload.payload, tcpPayload);
+});
+
+Deno.test("inetFrame: round-trips ethernet → ipv6 → udp → ntp", () => {
+  const coder = inetFrame();
+  const ntpPacket = {
+    leapVersionMode: { leapIndicator: 0, version: 4, mode: NTP_MODE.CLIENT },
+    stratum: 0,
+    poll: 4,
+    precision: -20,
+    rootDelay: 0,
+    rootDispersion: 0,
+    referenceId: 0,
+    referenceTimestamp: 0n,
+    originTimestamp: 0n,
+    receiveTimestamp: 0n,
+    transmitTimestamp: 0xe4c5c46700000000n,
+  };
+  const value: FrameRefined = {
+    dstMac: new Uint8Array([0, 0, 0, 0, 0, 1]),
+    srcMac: new Uint8Array([0, 0, 0, 0, 0, 2]),
+    etherType: ETHERTYPE_IPV6,
+    payload: {
+      versionClassFlow: { version: 6, trafficClass: 0, flowLabel: 0 },
+      payloadLength: 8 + NTP_PACKET_SIZE,
+      nextHeader: IP_PROTOCOL_UDP,
+      hopLimit: 64,
+      sourceAddress: new Uint8Array(16).fill(0x11),
+      destinationAddress: new Uint8Array(16).fill(0x22),
+      payload: {
+        srcPort: 49152,
+        dstPort: NTP_PORT,
+        length: 8 + NTP_PACKET_SIZE,
+        checksum: 0,
+        payload: ntpPacket,
+      },
+    },
+  };
+
+  const buf = new Uint8Array(128);
+  const written = coder.encode(value, buf);
+  const [decoded, read] = coder.decode(buf.subarray(0, written));
+
+  assertEquals(read, written);
+  const ip = decoded.payload as Ipv6UdpPacket;
+  const udp = ip.payload as UdpNtpPacket;
+  assertEquals(udp.dstPort, NTP_PORT);
+  assertEquals(udp.payload.leapVersionMode.mode, NTP_MODE.CLIENT);
+  assertEquals(udp.payload.transmitTimestamp, 0xe4c5c46700000000n);
+});
+
+Deno.test("inetFrame: round-trips ethernet → ipv6 → icmpv6", () => {
+  const coder = inetFrame();
+  const body = new Uint8Array([0xbe, 0xef, 0x00, 0x2a]);
+  const value: FrameRefined = {
+    dstMac: new Uint8Array([0, 0, 0, 0, 0, 1]),
+    srcMac: new Uint8Array([0, 0, 0, 0, 0, 2]),
+    etherType: ETHERTYPE_IPV6,
+    payload: {
+      versionClassFlow: { version: 6, trafficClass: 0, flowLabel: 0 },
+      payloadLength: 4 + body.length,
+      nextHeader: IP_PROTOCOL_ICMPV6,
+      hopLimit: 64,
+      sourceAddress: new Uint8Array(16).fill(0x11),
+      destinationAddress: new Uint8Array(16).fill(0x22),
+      payload: {
+        type: ICMPV6_TYPE.ECHO_REQUEST,
+        code: 0,
+        checksum: 0,
+        body,
+      },
+    },
+  };
+
+  const buf = new Uint8Array(64);
+  const written = coder.encode(value, buf);
+  const [decoded, read] = coder.decode(buf.subarray(0, written));
+
+  assertEquals(read, written);
+  const ip = decoded.payload as Ipv6Icmpv6Packet;
+  assertEquals(ip.payload.type, ICMPV6_TYPE.ECHO_REQUEST);
+  assertEquals(ip.payload.body, body);
+});
+
+Deno.test("inetFrame: round-trips ethernet → ipv4 → igmp", () => {
+  const coder = inetFrame();
+  const value: FrameRefined = {
+    dstMac: new Uint8Array([0, 0, 0, 0, 0, 1]),
+    srcMac: new Uint8Array([0, 0, 0, 0, 0, 2]),
+    etherType: ETHERTYPE_IPV4,
+    payload: {
+      versionIhl: { version: 4, ihl: 5 },
+      typeOfService: 0,
+      totalLength: 20 + 8,
+      identification: 0,
+      flagsFragmentOffset: {
+        reserved: 0,
+        dontFragment: 0,
+        moreFragments: 0,
+        fragmentOffset: 0,
+      },
+      timeToLive: 1,
+      protocol: IP_PROTOCOL_IGMP,
+      headerChecksum: 0,
+      sourceAddress: parseIpv4("10.0.0.5"),
+      destinationAddress: parseIpv4("224.0.0.1"),
+      options: new Uint8Array(0),
+      payload: {
+        type: IGMP_TYPE.V2_MEMBERSHIP_REPORT,
+        maxResponseTime: 0,
+        checksum: 0,
+        groupAddress: 0xe0000005,
+      },
+    },
+  };
+
+  const buf = new Uint8Array(64);
+  const written = coder.encode(value, buf);
+  const [decoded, read] = coder.decode(buf.subarray(0, written));
+
+  assertEquals(read, written);
+  const ip = decoded.payload as Ipv4IgmpPacket;
+  assertEquals(ip.payload.type, IGMP_TYPE.V2_MEMBERSHIP_REPORT);
+  assertEquals(ip.payload.groupAddress, 0xe0000005);
+});
+
+Deno.test("inetFrame: round-trips ethernet → ipv4 → esp", () => {
+  const coder = inetFrame();
+  const payloadData = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+  const value: FrameRefined = {
+    dstMac: new Uint8Array([0, 0, 0, 0, 0, 1]),
+    srcMac: new Uint8Array([0, 0, 0, 0, 0, 2]),
+    etherType: ETHERTYPE_IPV4,
+    payload: {
+      versionIhl: { version: 4, ihl: 5 },
+      typeOfService: 0,
+      totalLength: 20 + 8 + payloadData.length,
+      identification: 0,
+      flagsFragmentOffset: {
+        reserved: 0,
+        dontFragment: 0,
+        moreFragments: 0,
+        fragmentOffset: 0,
+      },
+      timeToLive: 64,
+      protocol: IP_PROTOCOL_ESP,
+      headerChecksum: 0,
+      sourceAddress: parseIpv4("10.0.0.1"),
+      destinationAddress: parseIpv4("10.0.0.2"),
+      options: new Uint8Array(0),
+      payload: {
+        spi: 0x12345678,
+        sequenceNumber: 1,
+        payloadData,
+      },
+    },
+  };
+
+  const buf = new Uint8Array(64);
+  const written = coder.encode(value, buf);
+  const [decoded, read] = coder.decode(buf.subarray(0, written));
+
+  assertEquals(read, written);
+  const ip = decoded.payload as Ipv4EspPacket;
+  assertEquals(ip.payload.spi, 0x12345678);
+  assertEquals(ip.payload.payloadData, payloadData);
+});
+
+Deno.test("inetFrame: round-trips a full VXLAN tunnel (udp:4789 → vxlan → ethernet → ipv4 → udp)", () => {
+  const coder = inetFrame();
+
+  const innerUdpPayload = new Uint8Array([0xca, 0xfe]);
+  const innerUdp = {
+    srcPort: 5000,
+    dstPort: 6000,
+    length: 8 + innerUdpPayload.length,
+    checksum: 0,
+    payload: innerUdpPayload,
+  };
+  const innerIpv4TotalLength = 20 + 8 + innerUdpPayload.length;
+  const innerIpv4 = {
+    versionIhl: { version: 4, ihl: 5 },
+    typeOfService: 0,
+    totalLength: innerIpv4TotalLength,
+    identification: 0,
+    flagsFragmentOffset: {
+      reserved: 0,
+      dontFragment: 0,
+      moreFragments: 0,
+      fragmentOffset: 0,
+    },
+    timeToLive: 64,
+    protocol: IP_PROTOCOL_UDP,
+    headerChecksum: 0,
+    sourceAddress: parseIpv4("192.168.1.1"),
+    destinationAddress: parseIpv4("192.168.1.2"),
+    options: new Uint8Array(0),
+    payload: innerUdp,
+  };
+  const innerFrame: FrameRefined = {
+    dstMac: new Uint8Array([0, 0, 0, 0, 0, 0xaa]),
+    srcMac: new Uint8Array([0, 0, 0, 0, 0, 0xbb]),
+    etherType: ETHERTYPE_IPV4,
+    payload: innerIpv4,
+  };
+  const innerFrameSize = 14 + innerIpv4TotalLength;
+
+  const vxlan = {
+    flagsReserved1: { flags: VXLAN_FLAG_VALID_VNI, reserved1: 0 },
+    vniReserved2: { vni: 42, reserved2: 0 },
+    innerFrame,
+  };
+  const vxlanSize = VXLAN_HEADER_SIZE + innerFrameSize;
+
+  const outerUdp = {
+    srcPort: 33333,
+    dstPort: VXLAN_PORT,
+    length: 8 + vxlanSize,
+    checksum: 0,
+    payload: vxlan,
+  };
+  const outerIpv4TotalLength = 20 + 8 + vxlanSize;
+  const value: FrameRefined = {
+    dstMac: new Uint8Array([0, 0, 0, 0, 0, 1]),
+    srcMac: new Uint8Array([0, 0, 0, 0, 0, 2]),
+    etherType: ETHERTYPE_IPV4,
+    payload: {
+      versionIhl: { version: 4, ihl: 5 },
+      typeOfService: 0,
+      totalLength: outerIpv4TotalLength,
+      identification: 0,
+      flagsFragmentOffset: {
+        reserved: 0,
+        dontFragment: 0,
+        moreFragments: 0,
+        fragmentOffset: 0,
+      },
+      timeToLive: 64,
+      protocol: IP_PROTOCOL_UDP,
+      headerChecksum: 0,
+      sourceAddress: parseIpv4("10.1.1.1"),
+      destinationAddress: parseIpv4("10.1.1.2"),
+      options: new Uint8Array(0),
+      payload: outerUdp,
+    },
+  };
+
+  const buf = new Uint8Array(256);
+  const written = coder.encode(value, buf);
+  const [decoded, read] = coder.decode(buf.subarray(0, written));
+
+  assertEquals(read, written);
+  const outerIp = decoded.payload as Ipv4UdpPacket;
+  const outerUdpDecoded = outerIp.payload as UdpVxlanPacket;
+  assertEquals(outerUdpDecoded.dstPort, VXLAN_PORT);
+  const vxlanDecoded = outerUdpDecoded.payload;
+  assertEquals(vxlanDecoded.vniReserved2.vni, 42);
+  const innerFrameDecoded = vxlanDecoded.innerFrame as Ipv4Frame;
+  assertEquals(innerFrameDecoded.etherType, ETHERTYPE_IPV4);
+  const innerIpDecoded = innerFrameDecoded.payload as Ipv4UdpPacket;
+  const innerUdpDecoded = innerIpDecoded.payload as UdpPacket;
+  assertEquals(innerUdpDecoded.srcPort, 5000);
+  assertEquals(innerUdpDecoded.payload, innerUdpPayload);
+});
+
+Deno.test("inetFrame: decodes a hand-built VXLAN tunnel from known wire bytes", () => {
+  // Outer Ethernet(14) + IPv4(20) + UDP(8) + VXLAN(8) + inner Ethernet(14) +
+  // inner IPv4(20, no payload) = 84 bytes total.
+  // deno-fmt-ignore
+  const wire = new Uint8Array([
+    // Outer Ethernet
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // dstMac
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x02, // srcMac
+    0x08, 0x00,                         // etherType: IPv4
+    // Outer IPv4
+    0x45, 0x00,             // version=4, ihl=5, tos=0
+    0x00, 0x46,             // totalLength = 70
+    0x00, 0x00,             // identification
+    0x00, 0x00,             // flags/fragmentOffset
+    0x40,                   // ttl = 64
+    0x11,                   // protocol = UDP
+    0x00, 0x00,             // headerChecksum
+    0x0a, 0x00, 0x00, 0x01, // srcIP 10.0.0.1
+    0x0a, 0x00, 0x00, 0x02, // dstIP 10.0.0.2
+    // Outer UDP
+    0x82, 0x3e,             // srcPort = 33342
+    0x12, 0xb5,             // dstPort = 4789 (VXLAN)
+    0x00, 0x32,             // length = 50
+    0x00, 0x00,             // checksum
+    // VXLAN header
+    0x08, 0x00, 0x00, 0x00, // flags = VALID_VNI, reserved1 = 0
+    0x00, 0x00, 0x2a, 0x00, // vni = 42, reserved2 = 0
+    // Inner Ethernet
+    0x00, 0x00, 0x00, 0x00, 0x00, 0xaa, // dstMac
+    0x00, 0x00, 0x00, 0x00, 0x00, 0xbb, // srcMac
+    0x08, 0x00,                         // etherType: IPv4
+    // Inner IPv4 (no payload)
+    0x45, 0x00,             // version=4, ihl=5, tos=0
+    0x00, 0x14,             // totalLength = 20
+    0x00, 0x00,             // identification
+    0x00, 0x00,             // flags/fragmentOffset
+    0x40,                   // ttl = 64
+    0xfd,                   // protocol = 253 (reserved for experimentation)
+    0x00, 0x00,             // headerChecksum
+    0x0a, 0x01, 0x01, 0x01, // srcIP 10.1.1.1
+    0x0a, 0x01, 0x01, 0x02, // dstIP 10.1.1.2
+  ]);
+
+  const coder = inetFrame();
+  const [decoded, read] = coder.decode(wire);
+
+  assertEquals(read, wire.length);
+  const outerIp = decoded.payload as Ipv4UdpPacket;
+  const outerUdp = outerIp.payload as UdpVxlanPacket;
+  assertEquals(outerUdp.dstPort, VXLAN_PORT);
+  const vxlan = outerUdp.payload;
+  assertEquals(vxlan.vniReserved2.vni, 42);
+  const innerFrame = vxlan.innerFrame as Ipv4Frame;
+  assertEquals(innerFrame.etherType, ETHERTYPE_IPV4);
+  assertEquals(innerFrame.payload.protocol, 253);
+
+  // Re-encoding the decoded value reproduces the exact same bytes.
+  const buf = new Uint8Array(wire.length);
+  const written = coder.encode(decoded, buf);
+  assertEquals(written, wire.length);
+  assertEquals(buf, wire);
+});
+
+Deno.test("inetFrame: two independent decodes through the same coder instance both resolve nested VXLAN tunnels", () => {
+  // deno-fmt-ignore
+  const wire = new Uint8Array([
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+    0x08, 0x00,
+    0x45, 0x00,
+    0x00, 0x46,
+    0x00, 0x00,
+    0x00, 0x00,
+    0x40,
+    0x11,
+    0x00, 0x00,
+    0x0a, 0x00, 0x00, 0x01,
+    0x0a, 0x00, 0x00, 0x02,
+    0x82, 0x3e,
+    0x12, 0xb5,
+    0x00, 0x32,
+    0x00, 0x00,
+    0x08, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x2a, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0xaa,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0xbb,
+    0x08, 0x00,
+    0x45, 0x00,
+    0x00, 0x14,
+    0x00, 0x00,
+    0x00, 0x00,
+    0x40,
+    0xfd,
+    0x00, 0x00,
+    0x0a, 0x01, 0x01, 0x01,
+    0x0a, 0x01, 0x01, 0x02,
+  ]);
+
+  const coder = inetFrame();
+
+  const [firstDecoded] = coder.decode(wire);
+  const firstOuterUdp = (firstDecoded.payload as Ipv4UdpPacket)
+    .payload as UdpVxlanPacket;
+  assertEquals(firstOuterUdp.payload.vniReserved2.vni, 42);
+
+  const [secondDecoded] = coder.decode(wire);
+  const secondOuterUdp = (secondDecoded.payload as Ipv4UdpPacket)
+    .payload as UdpVxlanPacket;
+  assertEquals(secondOuterUdp.payload.vniReserved2.vni, 42);
+
+  assertEquals(firstDecoded, secondDecoded);
+});
+
+Deno.test("inetFrame: UDP port ambiguity — destination port wins over source port", () => {
+  const coder = inetFrame();
+  const value: FrameRefined = {
+    dstMac: new Uint8Array([0, 0, 0, 0, 0, 1]),
+    srcMac: new Uint8Array([0, 0, 0, 0, 0, 2]),
+    etherType: ETHERTYPE_IPV4,
+    payload: {
+      versionIhl: { version: 4, ihl: 5 },
+      typeOfService: 0,
+      totalLength: 20 + 8 + BFD_CONTROL_SIZE,
+      identification: 0,
+      flagsFragmentOffset: {
+        reserved: 0,
+        dontFragment: 0,
+        moreFragments: 0,
+        fragmentOffset: 0,
+      },
+      timeToLive: 255,
+      protocol: IP_PROTOCOL_UDP,
+      headerChecksum: 0,
+      sourceAddress: parseIpv4("10.0.0.1"),
+      destinationAddress: parseIpv4("10.0.0.2"),
+      options: new Uint8Array(0),
+      payload: {
+        // srcPort matches NTP, dstPort matches BFD — dstPort must win.
+        srcPort: NTP_PORT,
+        dstPort: BFD_PORT,
+        length: 8 + BFD_CONTROL_SIZE,
+        checksum: 0,
+        payload: {
+          versionDiagnostic: { version: 1, diagnostic: 0 },
+          flags: {
+            state: BFD_STATE.UP,
+            poll: 0,
+            final: 0,
+            controlPlaneIndependent: 0,
+            authenticationPresent: 0,
+            demand: 0,
+            multipoint: 0,
+          },
+          detectMultiplier: 3,
+          length: BFD_CONTROL_SIZE,
+          myDiscriminator: 0x11111111,
+          yourDiscriminator: 0x22222222,
+          desiredMinTxInterval: 1_000_000,
+          requiredMinRxInterval: 1_000_000,
+          requiredMinEchoRxInterval: 0,
+        },
+      },
+    },
+  };
+
+  const buf = new Uint8Array(96);
+  const written = coder.encode(value, buf);
+  const [decoded, read] = coder.decode(buf.subarray(0, written));
+
+  assertEquals(read, written);
+  const ip = decoded.payload as Ipv4UdpPacket;
+  const udp = ip.payload as UdpBfdPacket;
+  assertEquals(udp.payload.flags.state, BFD_STATE.UP);
+});
+
+Deno.test("inetFrame: unknown UDP port stays a plain UdpPacket", () => {
+  const coder = inetFrame();
+  const payload = new Uint8Array([0x01, 0x02, 0x03]);
+  const value: FrameRefined = {
+    dstMac: new Uint8Array([0, 0, 0, 0, 0, 1]),
+    srcMac: new Uint8Array([0, 0, 0, 0, 0, 2]),
+    etherType: ETHERTYPE_IPV4,
+    payload: {
+      versionIhl: { version: 4, ihl: 5 },
+      typeOfService: 0,
+      totalLength: 20 + 8 + payload.length,
+      identification: 0,
+      flagsFragmentOffset: {
+        reserved: 0,
+        dontFragment: 0,
+        moreFragments: 0,
+        fragmentOffset: 0,
+      },
+      timeToLive: 64,
+      protocol: IP_PROTOCOL_UDP,
+      headerChecksum: 0,
+      sourceAddress: parseIpv4("10.0.0.1"),
+      destinationAddress: parseIpv4("10.0.0.2"),
+      options: new Uint8Array(0),
+      payload: {
+        srcPort: 40000,
+        dstPort: 40001,
+        length: 8 + payload.length,
+        checksum: 0,
+        payload,
+      },
+    },
+  };
+
+  const buf = new Uint8Array(64);
+  const written = coder.encode(value, buf);
+  const [decoded] = coder.decode(buf.subarray(0, written));
+
+  const ip = decoded.payload as Ipv4UdpPacket;
+  const udp = ip.payload as UdpRefined;
+  assert(udp.payload instanceof Uint8Array);
+  assertEquals(udp.payload, payload);
+});
+
+Deno.test("inetFrame: unknown IPv6 nextHeader stays a plain Ipv6Packet", () => {
+  const coder = inetFrame();
+  const payload = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
+  const value: FrameRefined = {
+    dstMac: new Uint8Array([0, 0, 0, 0, 0, 1]),
+    srcMac: new Uint8Array([0, 0, 0, 0, 0, 2]),
+    etherType: ETHERTYPE_IPV6,
+    payload: {
+      versionClassFlow: { version: 6, trafficClass: 0, flowLabel: 0 },
+      payloadLength: payload.length,
+      nextHeader: 200, // unassigned — no coder for it
+      hopLimit: 64,
+      sourceAddress: new Uint8Array(16).fill(0x11),
+      destinationAddress: new Uint8Array(16).fill(0x22),
+      payload,
+    },
+  };
+
+  const buf = new Uint8Array(64);
+  const written = coder.encode(value, buf);
+  const [decoded] = coder.decode(buf.subarray(0, written));
+
+  const ip = decoded.payload as Ipv6Refined;
+  assert(ip.payload instanceof Uint8Array);
+  assertEquals(ip.payload, payload);
+});
+
+Deno.test("sllInetFrame: round-trips sll → ipv4 → udp", () => {
+  const coder = sllInetFrame();
+  const udpPayload = new Uint8Array([0x01, 0x02]);
+  const value: SllFrameRefined = {
+    packetType: SLL_PACKET_TYPE.HOST,
+    arphrdType: 1,
+    linkLayerAddressLength: 6,
+    linkLayerAddress: new Uint8Array([
+      0x00,
+      0x11,
+      0x22,
+      0x33,
+      0x44,
+      0x55,
+      0x00,
+      0x00,
+    ]),
+    protocol: ETHERTYPE_IPV4,
+    payload: {
+      versionIhl: { version: 4, ihl: 5 },
+      typeOfService: 0,
+      totalLength: 20 + 8 + udpPayload.length,
+      identification: 0,
+      flagsFragmentOffset: {
+        reserved: 0,
+        dontFragment: 0,
+        moreFragments: 0,
+        fragmentOffset: 0,
+      },
+      timeToLive: 64,
+      protocol: IP_PROTOCOL_UDP,
+      headerChecksum: 0,
+      sourceAddress: parseIpv4("10.0.0.1"),
+      destinationAddress: parseIpv4("10.0.0.2"),
+      options: new Uint8Array(0),
+      payload: {
+        srcPort: 1234,
+        dstPort: 53,
+        length: 8 + udpPayload.length,
+        checksum: 0,
+        payload: udpPayload,
+      },
+    },
+  };
+
+  const buf = new Uint8Array(64);
+  const written = coder.encode(value, buf);
+  const [decoded, read] = coder.decode(buf.subarray(0, written));
+
+  assertEquals(read, written);
+  assertEquals(decoded.protocol, ETHERTYPE_IPV4);
+  const ip = decoded.payload as Ipv4UdpPacket;
+  const udp = ip.payload as UdpPacket;
+  assertEquals(udp.payload, udpPayload);
+});
+
+Deno.test("sllInetFrame: round-trips sll → arp", () => {
+  const coder = sllInetFrame();
+  const value: SllFrameRefined = {
+    packetType: SLL_PACKET_TYPE.HOST,
+    arphrdType: 1,
+    linkLayerAddressLength: 6,
+    linkLayerAddress: new Uint8Array([
+      0x00,
+      0x11,
+      0x22,
+      0x33,
+      0x44,
+      0x55,
+      0x00,
+      0x00,
+    ]),
+    protocol: ETHERTYPE_ARP,
+    payload: {
+      hardwareType: 1,
+      protocolType: 0x0800,
+      hardwareAddressLength: 6,
+      protocolAddressLength: 4,
+      operation: ARP_OPCODE.REQUEST,
+      senderHardwareAddress: new Uint8Array([0, 0, 0, 0, 0, 2]),
+      senderProtocolAddress: 0xc0000201,
+      targetHardwareAddress: new Uint8Array([0, 0, 0, 0, 0, 0]),
+      targetProtocolAddress: 0xc0000202,
+    },
+  };
+
+  const buf = new Uint8Array(64);
+  const written = coder.encode(value, buf);
+  const [decoded, read] = coder.decode(buf.subarray(0, written));
+
+  assertEquals(read, written);
+  assertEquals(decoded.protocol, ETHERTYPE_ARP);
+  assert(!(decoded.payload instanceof Uint8Array));
+  assert("operation" in decoded.payload);
+  assertEquals(decoded.payload.operation, ARP_OPCODE.REQUEST);
 });

--- a/packages/@binstruct/inet/mod.test.ts
+++ b/packages/@binstruct/inet/mod.test.ts
@@ -10,7 +10,12 @@ import { IP_PROTOCOL_ESP } from "@binstruct/esp";
 import { IP_PROTOCOL_TCP } from "@binstruct/tcp";
 import { IP_PROTOCOL_UDP, type UdpPacket } from "@binstruct/udp";
 import { TPID_8021Q } from "@binstruct/vlan";
-import { ETHERTYPE_PPPOE_SESSION, PPPOE_CODE } from "@binstruct/pppoe";
+import {
+  ETHERTYPE_PPPOE_DISCOVERY,
+  ETHERTYPE_PPPOE_SESSION,
+  PPPOE_CODE,
+  type PppoeHeader,
+} from "@binstruct/pppoe";
 import {
   VXLAN_FLAG_VALID_VNI,
   VXLAN_HEADER_SIZE,
@@ -28,6 +33,7 @@ import {
   type Ipv4IgmpPacket,
   type Ipv4TcpPacket,
   type Ipv4UdpPacket,
+  type Ipv6EspPacket,
   type Ipv6Icmpv6Packet,
   type Ipv6Refined,
   type Ipv6TcpPacket,
@@ -609,6 +615,33 @@ Deno.test("inetFrame: round-trips ethernet → pppoe-session → ppp(ipv6) → t
   assertEquals(ip.payload.payload, tcpPayload);
 });
 
+Deno.test("inetFrame: round-trips ethernet → pppoe-discovery (PADI)", () => {
+  const coder = inetFrame();
+  const tags = new Uint8Array([0x01, 0x01, 0x00, 0x00]); // Service-Name tag, empty
+  const value: FrameRefined = {
+    dstMac: new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
+    srcMac: new Uint8Array([0, 0, 0, 0, 0, 2]),
+    etherType: ETHERTYPE_PPPOE_DISCOVERY,
+    payload: {
+      versionType: { version: 1, type: 1 },
+      code: PPPOE_CODE.PADI,
+      sessionId: 0,
+      length: tags.length,
+      payload: tags,
+    },
+  };
+
+  const buf = new Uint8Array(32);
+  const written = coder.encode(value, buf);
+  const [decoded, read] = coder.decode(buf.subarray(0, written));
+
+  assertEquals(read, written);
+  assertEquals(decoded.etherType, ETHERTYPE_PPPOE_DISCOVERY);
+  const discovery = decoded.payload as PppoeHeader;
+  assertEquals(discovery.code, PPPOE_CODE.PADI);
+  assertEquals(discovery.payload, tags);
+});
+
 Deno.test("inetFrame: round-trips ethernet → ipv6 → udp → ntp", () => {
   const coder = inetFrame();
   const ntpPacket = {
@@ -688,6 +721,38 @@ Deno.test("inetFrame: round-trips ethernet → ipv6 → icmpv6", () => {
   const ip = decoded.payload as Ipv6Icmpv6Packet;
   assertEquals(ip.payload.type, ICMPV6_TYPE.ECHO_REQUEST);
   assertEquals(ip.payload.body, body);
+});
+
+Deno.test("inetFrame: round-trips ethernet → ipv6 → esp", () => {
+  const coder = inetFrame();
+  const payloadData = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+  const value: FrameRefined = {
+    dstMac: new Uint8Array([0, 0, 0, 0, 0, 1]),
+    srcMac: new Uint8Array([0, 0, 0, 0, 0, 2]),
+    etherType: ETHERTYPE_IPV6,
+    payload: {
+      versionClassFlow: { version: 6, trafficClass: 0, flowLabel: 0 },
+      payloadLength: 8 + payloadData.length,
+      nextHeader: IP_PROTOCOL_ESP,
+      hopLimit: 64,
+      sourceAddress: new Uint8Array(16).fill(0x11),
+      destinationAddress: new Uint8Array(16).fill(0x22),
+      payload: {
+        spi: 0x12345678,
+        sequenceNumber: 1,
+        payloadData,
+      },
+    },
+  };
+
+  const buf = new Uint8Array(128);
+  const written = coder.encode(value, buf);
+  const [decoded, read] = coder.decode(buf.subarray(0, written));
+
+  assertEquals(read, written);
+  const ip = decoded.payload as Ipv6EspPacket;
+  assertEquals(ip.payload.spi, 0x12345678);
+  assertEquals(ip.payload.payloadData, payloadData);
 });
 
 Deno.test("inetFrame: round-trips ethernet → ipv4 → igmp", () => {
@@ -1212,4 +1277,67 @@ Deno.test("sllInetFrame: round-trips sll → arp", () => {
   assert(!(decoded.payload instanceof Uint8Array));
   assert("operation" in decoded.payload);
   assertEquals(decoded.payload.operation, ARP_OPCODE.REQUEST);
+});
+
+Deno.test("sllInetFrame: round-trips sll → vlan → ipv4 → udp", () => {
+  const coder = sllInetFrame();
+  const udpPayload = new Uint8Array([0xaa, 0xbb]);
+  const value: SllFrameRefined = {
+    packetType: SLL_PACKET_TYPE.HOST,
+    arphrdType: 1,
+    linkLayerAddressLength: 6,
+    linkLayerAddress: new Uint8Array([
+      0x00,
+      0x11,
+      0x22,
+      0x33,
+      0x44,
+      0x55,
+      0x00,
+      0x00,
+    ]),
+    protocol: TPID_8021Q,
+    payload: {
+      tci: { pcp: 0, dei: 0, vlanId: 100 },
+      etherType: ETHERTYPE_IPV4,
+      payload: {
+        versionIhl: { version: 4, ihl: 5 },
+        typeOfService: 0,
+        totalLength: 20 + 8 + udpPayload.length,
+        identification: 0,
+        flagsFragmentOffset: {
+          reserved: 0,
+          dontFragment: 0,
+          moreFragments: 0,
+          fragmentOffset: 0,
+        },
+        timeToLive: 64,
+        protocol: IP_PROTOCOL_UDP,
+        headerChecksum: 0,
+        sourceAddress: parseIpv4("10.0.0.1"),
+        destinationAddress: parseIpv4("10.0.0.2"),
+        options: new Uint8Array(0),
+        payload: {
+          srcPort: 1111,
+          dstPort: 2222,
+          length: 8 + udpPayload.length,
+          checksum: 0,
+          payload: udpPayload,
+        },
+      },
+    },
+  };
+
+  const buf = new Uint8Array(128);
+  const written = coder.encode(value, buf);
+  const [decoded, read] = coder.decode(buf.subarray(0, written));
+
+  assertEquals(read, written);
+  assertEquals(decoded.protocol, TPID_8021Q);
+  const vlan = decoded.payload as VlanIpv4Frame;
+  assertEquals(vlan.tci.vlanId, 100);
+  const ip = vlan.payload;
+  assertEquals(ip.protocol, IP_PROTOCOL_UDP);
+  const udp = ip.payload as UdpPacket;
+  assertEquals(udp.payload, udpPayload);
 });

--- a/packages/@binstruct/inet/mod.ts
+++ b/packages/@binstruct/inet/mod.ts
@@ -2,22 +2,37 @@
  * Inet stack coder for the `@binstruct/*` packet family.
  *
  * `@binstruct/inet` is a thin orchestration layer: each protocol package
- * (`@binstruct/ethernet`, `@binstruct/ipv4`, `@binstruct/arp`,
- * `@binstruct/udp`, `@binstruct/icmp`) only knows how to decode its own
- * layer's bytes. This package wires them together via `refineSwitch` and
- * `refineFields` — dispatching on `etherType` at L3 and `protocol` at L4 —
- * into a single round-trippable {@linkcode inetFrame} coder factory that
- * walks an Ethernet II frame top-down. Each layer's `payload` field is
- * surfaced as the typed value of the next layer; layers we don't have a
- * coder for default to a raw {@linkcode Uint8Array}, so the coder is safe
- * to point at arbitrary captured traffic.
+ * (`@binstruct/ethernet`, `@binstruct/sll`, `@binstruct/vlan`,
+ * `@binstruct/pppoe`, `@binstruct/ipv4`, `@binstruct/ipv6`, `@binstruct/arp`,
+ * `@binstruct/tcp`, `@binstruct/udp`, `@binstruct/icmp`, `@binstruct/icmpv6`,
+ * `@binstruct/igmp`, `@binstruct/esp`, `@binstruct/vxlan`, `@binstruct/ntp`,
+ * `@binstruct/bfd`) only knows how to decode its own layer's bytes. This
+ * package wires them together via `refineSwitch` and `refineFields` —
+ * dispatching on a host discriminator field at every layer (`etherType` /
+ * `protocol`, `nextHeader`, IP `protocol`, UDP port, PPP protocol ID) — into
+ * round-trippable coder factories that walk a captured frame top-down. Each
+ * layer's payload field is surfaced as the typed value of the next layer;
+ * layers we don't have a coder for default to a raw {@linkcode Uint8Array},
+ * so the coders are safe to point at arbitrary captured traffic.
  *
  * Coverage:
  *
- * - L2 — Ethernet II (`@binstruct/ethernet`)
- * - L3 — IPv4 (`@binstruct/ipv4`), ARP (`@binstruct/arp`)
- * - L4 (under IPv4) — TCP (`@binstruct/tcp`), UDP (`@binstruct/udp`),
- *   ICMPv4 (`@binstruct/icmp`)
+ * - L2 — Ethernet II ({@linkcode inetFrame}, `@binstruct/ethernet`) and Linux
+ *   cooked capture ({@linkcode sllInetFrame}, `@binstruct/sll`), each a
+ *   separate root sharing the same L3 dispatch logic.
+ * - L2.5 — IEEE 802.1Q VLAN tagging (`@binstruct/vlan`), including a single
+ *   bounded level of QinQ double-tagging, and PPPoE (`@binstruct/pppoe`)
+ *   Discovery and Session stages, the latter carrying an internal PPP
+ *   protocol-ID mini-layer that dispatches to IPv4/IPv6.
+ * - L3 — IPv4 (`@binstruct/ipv4`), IPv6 (`@binstruct/ipv6`), ARP
+ *   (`@binstruct/arp`).
+ * - L4 (under IPv4/IPv6) — TCP (`@binstruct/tcp`), UDP (`@binstruct/udp`),
+ *   ICMPv4 (`@binstruct/icmp`), ICMPv6 (`@binstruct/icmpv6`), IGMP
+ *   (`@binstruct/igmp`, IPv4 only), ESP (`@binstruct/esp`).
+ * - L4 (under UDP) — port-based dispatch to VXLAN (`@binstruct/vxlan`, whose
+ *   inner Ethernet frame tunnels back through {@linkcode inetFrame} via a
+ *   `lazy()` coder to break the build-time recursion), NTP (`@binstruct/ntp`),
+ *   and BFD (`@binstruct/bfd`).
  *
  * Adding a layer is one new `refineFields` arm in the relevant
  * `refineSwitch` plus an entry in its selector.
@@ -26,10 +41,11 @@
  * to fill in IPv4/UDP/ICMP/TCP checksum fields.
  *
  * Each refined `payload` is the typed value directly — no `{ kind, ... }`
- * wrapper. The on-wire tag (`etherType` at L3, `protocol` at L4) on the host
- * record is the discriminator; narrow the union with property-existence
- * checks (`"protocol" in payload`, `"srcPort" in payload`, …) when reading
- * decoded values.
+ * wrapper. The on-wire tag (`etherType` / `protocol` at L3, IP `protocol` /
+ * `nextHeader` at L4, UDP port, PPP protocol ID) on the host record is the
+ * discriminator; narrow the union with property-existence checks
+ * (`"protocol" in payload`, `"srcPort" in payload`, …) when reading decoded
+ * values.
  *
  * @example Round-trip a UDP-over-IPv4-over-Ethernet frame
  * ```ts
@@ -80,57 +96,162 @@
  * @module
  */
 
-import { type Coder, refineFields, refineSwitch } from "@hertzg/binstruct";
+import {
+  bytes,
+  type Coder,
+  lazy,
+  refine,
+  refineFields,
+  type Refiner,
+  refineSwitch,
+  struct,
+  u16be,
+} from "@hertzg/binstruct";
 import {
   type Ethernet2Frame as Frame,
   ethernet2Frame,
 } from "@binstruct/ethernet";
-import { type ArpData, arpData, ETHERTYPE_ARP } from "@binstruct/arp";
+import { type SllHeader, sllHeader } from "@binstruct/sll";
+import { TPID_8021Q, type VlanTag, vlanTag } from "@binstruct/vlan";
 import {
-  ETHERTYPE_IPV4,
-  type Ipv4Packet,
-  ipv4Packet,
-} from "@binstruct/ipv4";
+  ETHERTYPE_PPPOE_DISCOVERY,
+  ETHERTYPE_PPPOE_SESSION,
+  type PppoeHeader,
+  pppoeHeader,
+} from "@binstruct/pppoe";
+import { type ArpData, arpData, ETHERTYPE_ARP } from "@binstruct/arp";
+import { ETHERTYPE_IPV4, type Ipv4Packet, ipv4Packet } from "@binstruct/ipv4";
+import { ETHERTYPE_IPV6, type Ipv6Packet, ipv6Packet } from "@binstruct/ipv6";
 import { type IcmpPacket, icmpPacket, IP_PROTOCOL_ICMP } from "@binstruct/icmp";
+import {
+  type Icmpv6Message,
+  icmpv6Message,
+  IP_PROTOCOL_ICMPV6,
+} from "@binstruct/icmpv6";
+import {
+  type IgmpMessage,
+  igmpMessage,
+  IP_PROTOCOL_IGMP,
+} from "@binstruct/igmp";
+import { type EspPacket, espPacket, IP_PROTOCOL_ESP } from "@binstruct/esp";
 import { IP_PROTOCOL_TCP, type TcpPacket, tcpPacket } from "@binstruct/tcp";
 import { IP_PROTOCOL_UDP, type UdpPacket, udpPacket } from "@binstruct/udp";
+import { VXLAN_PORT, type VxlanHeader, vxlanHeader } from "@binstruct/vxlan";
+import { NTP_PORT, type NtpPacket, ntpPacket } from "@binstruct/ntp";
+import {
+  BFD_PORT,
+  type BfdControlPacket,
+  bfdControlPacket,
+} from "@binstruct/bfd";
 
-/** IPv4 datagram with a typed TCP transport payload. */
-export type Ipv4TcpPacket = Omit<Ipv4Packet, "payload"> & {
-  payload: TcpPacket;
+/**
+ * Creates a coder for a VXLAN-tunneled Ethernet frame — the 8-byte VXLAN
+ * header (`@binstruct/vxlan`) whose inner frame is the *same* Ethernet
+ * encapsulation stack this module already knows how to decode.
+ *
+ * The inner frame is wrapped in `lazy()` rather than calling
+ * {@linkcode inetFrame} directly: `udpFrame()` (built below) has a "vxlan"
+ * arm that reaches this function, and this function's inner frame reaches
+ * back to `inetFrame()` — a genuine build-time cycle. `lazy()` defers
+ * resolving `inetFrame()` until the first encode/decode of an actual VXLAN
+ * packet, breaking the cycle at coder-*construction* time. It does not
+ * bound *decode-time* recursion — a maliciously nested VXLAN-in-VXLAN
+ * capture still recurses once per level actually present in the bytes.
+ *
+ * @returns A coder for {@linkcode VxlanEthernetFrame} values.
+ */
+function vxlanFrame(): Coder<VxlanEthernetFrame> {
+  return refine(
+    vxlanHeader(),
+    refineFields({ innerFrame: lazy(() => inetFrame()) }),
+  )();
+}
+
+/** VXLAN header whose inner frame is a typed Ethernet stack. */
+export type VxlanEthernetFrame = Omit<VxlanHeader, "innerFrame"> & {
+  innerFrame: FrameRefined;
 };
 
-/** IPv4 datagram with a typed UDP transport payload. */
-export type Ipv4UdpPacket = Omit<Ipv4Packet, "payload"> & {
-  payload: UdpPacket;
+function classifyPort(port: number): "vxlan" | "ntp" | "bfd" | null {
+  switch (port) {
+    case VXLAN_PORT:
+      return "vxlan";
+    case NTP_PORT:
+      return "ntp";
+    case BFD_PORT:
+      return "bfd";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Creates a coder for a UDP datagram whose payload is dispatched by UDP
+ * port, on top of the base header/length framing from `@binstruct/udp`.
+ *
+ * The selector is a heuristic — `classifyPort(dstPort) ?? classifyPort(srcPort)`
+ * (destination port wins, falling back to the source port) — since UDP has
+ * no in-band type tag. It round-trips symmetrically for well-formed traffic
+ * but can misclassify adversarial or reused-port traffic; that's inherent to
+ * port-based dispatch, not fixable at this layer.
+ *
+ * @returns A coder for {@linkcode UdpRefined} values.
+ */
+function udpFrame(): Coder<UdpRefined> {
+  return refineSwitch(
+    udpPacket(),
+    {
+      vxlan: refineFields({ payload: vxlanFrame() }),
+      ntp: refineFields({ payload: ntpPacket() }),
+      bfd: refineFields({ payload: bfdControlPacket() }),
+      raw: refineFields({}),
+    },
+    {
+      refine: (d): "vxlan" | "ntp" | "bfd" | "raw" =>
+        classifyPort(d.dstPort) ?? classifyPort(d.srcPort) ?? "raw",
+      unrefine: (r): "vxlan" | "ntp" | "bfd" | "raw" =>
+        classifyPort(r.dstPort) ?? classifyPort(r.srcPort) ?? "raw",
+    },
+  );
+}
+
+/** UDP datagram with a typed VXLAN transport payload. */
+export type UdpVxlanPacket = Omit<UdpPacket, "payload"> & {
+  payload: VxlanEthernetFrame;
 };
 
-/** IPv4 datagram with a typed ICMPv4 transport payload. */
-export type Ipv4IcmpPacket = Omit<Ipv4Packet, "payload"> & {
-  payload: IcmpPacket;
+/** UDP datagram with a typed NTP transport payload. */
+export type UdpNtpPacket = Omit<UdpPacket, "payload"> & { payload: NtpPacket };
+
+/** UDP datagram with a typed BFD control payload. */
+export type UdpBfdPacket = Omit<UdpPacket, "payload"> & {
+  payload: BfdControlPacket;
 };
 
 /**
- * Refined IPv4 datagram — `payload` narrows by shape (TCP / UDP / ICMP / raw
- * bytes) and the host's `protocol` field is the on-wire discriminator.
+ * Refined UDP datagram — `payload` narrows by shape (VXLAN / NTP / BFD /
+ * raw bytes), dispatched by destination port (falling back to source port)
+ * since UDP carries no in-band type tag. See {@linkcode udpFrame}.
  */
-export type Ipv4Refined =
-  | Ipv4TcpPacket
-  | Ipv4UdpPacket
-  | Ipv4IcmpPacket
-  | Ipv4Packet;
+export type UdpRefined =
+  | UdpVxlanPacket
+  | UdpNtpPacket
+  | UdpBfdPacket
+  | UdpPacket;
 
 function ipv4Frame(): Coder<Ipv4Refined> {
   return refineSwitch(
     ipv4Packet(),
     {
       tcp: refineFields({ payload: tcpPacket() }),
-      udp: refineFields({ payload: udpPacket() }),
+      udp: refineFields({ payload: udpFrame() }),
       icmp: refineFields({ payload: icmpPacket() }),
+      igmp: refineFields({ payload: igmpMessage() }),
+      esp: refineFields({ payload: espPacket() }),
       raw: refineFields({}),
     },
     {
-      refine: (d): "tcp" | "udp" | "icmp" | "raw" => {
+      refine: (d): "tcp" | "udp" | "icmp" | "igmp" | "esp" | "raw" => {
         switch (d.protocol) {
           case IP_PROTOCOL_TCP:
             return "tcp";
@@ -138,11 +259,15 @@ function ipv4Frame(): Coder<Ipv4Refined> {
             return "udp";
           case IP_PROTOCOL_ICMP:
             return "icmp";
+          case IP_PROTOCOL_IGMP:
+            return "igmp";
+          case IP_PROTOCOL_ESP:
+            return "esp";
           default:
             return "raw";
         }
       },
-      unrefine: (r): "tcp" | "udp" | "icmp" | "raw" => {
+      unrefine: (r): "tcp" | "udp" | "icmp" | "igmp" | "esp" | "raw" => {
         switch (r.protocol) {
           case IP_PROTOCOL_TCP:
             return "tcp";
@@ -150,6 +275,10 @@ function ipv4Frame(): Coder<Ipv4Refined> {
             return "udp";
           case IP_PROTOCOL_ICMP:
             return "icmp";
+          case IP_PROTOCOL_IGMP:
+            return "igmp";
+          case IP_PROTOCOL_ESP:
+            return "esp";
           default:
             return "raw";
         }
@@ -158,57 +287,541 @@ function ipv4Frame(): Coder<Ipv4Refined> {
   );
 }
 
+/** IPv4 datagram with a typed TCP transport payload. */
+export type Ipv4TcpPacket = Omit<Ipv4Packet, "payload"> & {
+  payload: TcpPacket;
+};
+
+/** IPv4 datagram with a typed UDP transport payload. */
+export type Ipv4UdpPacket = Omit<Ipv4Packet, "payload"> & {
+  payload: UdpRefined;
+};
+
+/** IPv4 datagram with a typed ICMPv4 transport payload. */
+export type Ipv4IcmpPacket = Omit<Ipv4Packet, "payload"> & {
+  payload: IcmpPacket;
+};
+
+/** IPv4 datagram with a typed IGMP transport payload. */
+export type Ipv4IgmpPacket = Omit<Ipv4Packet, "payload"> & {
+  payload: IgmpMessage;
+};
+
+/** IPv4 datagram with a typed ESP transport payload. */
+export type Ipv4EspPacket = Omit<Ipv4Packet, "payload"> & {
+  payload: EspPacket;
+};
+
+/**
+ * Refined IPv4 datagram — `payload` narrows by shape (TCP / UDP / ICMP /
+ * IGMP / ESP / raw bytes) and the host's `protocol` field is the on-wire
+ * discriminator.
+ */
+export type Ipv4Refined =
+  | Ipv4TcpPacket
+  | Ipv4UdpPacket
+  | Ipv4IcmpPacket
+  | Ipv4IgmpPacket
+  | Ipv4EspPacket
+  | Ipv4Packet;
+
+function ipv6Frame(): Coder<Ipv6Refined> {
+  return refineSwitch(
+    ipv6Packet(),
+    {
+      tcp: refineFields({ payload: tcpPacket() }),
+      udp: refineFields({ payload: udpFrame() }),
+      icmpv6: refineFields({ payload: icmpv6Message() }),
+      esp: refineFields({ payload: espPacket() }),
+      raw: refineFields({}),
+    },
+    {
+      refine: (d): "tcp" | "udp" | "icmpv6" | "esp" | "raw" => {
+        switch (d.nextHeader) {
+          case IP_PROTOCOL_TCP:
+            return "tcp";
+          case IP_PROTOCOL_UDP:
+            return "udp";
+          case IP_PROTOCOL_ICMPV6:
+            return "icmpv6";
+          case IP_PROTOCOL_ESP:
+            return "esp";
+          default:
+            return "raw";
+        }
+      },
+      unrefine: (r): "tcp" | "udp" | "icmpv6" | "esp" | "raw" => {
+        switch (r.nextHeader) {
+          case IP_PROTOCOL_TCP:
+            return "tcp";
+          case IP_PROTOCOL_UDP:
+            return "udp";
+          case IP_PROTOCOL_ICMPV6:
+            return "icmpv6";
+          case IP_PROTOCOL_ESP:
+            return "esp";
+          default:
+            return "raw";
+        }
+      },
+    },
+  );
+}
+
+/** IPv6 packet with a typed TCP transport payload. */
+export type Ipv6TcpPacket = Omit<Ipv6Packet, "payload"> & {
+  payload: TcpPacket;
+};
+
+/** IPv6 packet with a typed UDP transport payload. */
+export type Ipv6UdpPacket = Omit<Ipv6Packet, "payload"> & {
+  payload: UdpRefined;
+};
+
+/** IPv6 packet with a typed ICMPv6 transport payload. */
+export type Ipv6Icmpv6Packet = Omit<Ipv6Packet, "payload"> & {
+  payload: Icmpv6Message;
+};
+
+/** IPv6 packet with a typed ESP transport payload. */
+export type Ipv6EspPacket = Omit<Ipv6Packet, "payload"> & {
+  payload: EspPacket;
+};
+
+/**
+ * Refined IPv6 packet — `payload` narrows by shape (TCP / UDP / ICMPv6 /
+ * ESP / raw bytes) and the host's `nextHeader` field is the on-wire
+ * discriminator.
+ *
+ * `@binstruct/ipv6` is a header-only (v0.0.1) coder: it does not walk
+ * extension headers (Hop-by-Hop, Routing, Fragment, Destination Options).
+ * A packet whose `nextHeader` names an extension header rather than a real
+ * upper-layer protocol lands in the raw fallback here too — that's a
+ * pre-existing `@binstruct/ipv6` limitation, not something this layer can
+ * see through.
+ */
+export type Ipv6Refined =
+  | Ipv6TcpPacket
+  | Ipv6UdpPacket
+  | Ipv6Icmpv6Packet
+  | Ipv6EspPacket
+  | Ipv6Packet;
+
+const PPP_PROTOCOL_IPV4 = 0x0021;
+const PPP_PROTOCOL_IPV6 = 0x0057;
+
+/** Base PPP frame as carried inside a PPPoE Session payload: a 2-byte
+ * protocol ID (RFC 1661 §2) followed by the protocol's payload. Not modeled
+ * by `@binstruct/pppoe` itself — see the module docs there. */
+interface PppHost {
+  pppProtocol: number;
+  payload: Uint8Array;
+}
+
+/**
+ * Creates a coder for the PPP protocol-ID mini-layer carried inside a PPPoE
+ * Session payload (RFC 1661 §2): a 2-byte protocol ID followed by the
+ * protocol's payload, dispatching `0x0021` to IPv4 and `0x0057` to IPv6.
+ *
+ * This lives entirely inside `@binstruct/inet` rather than as new surface on
+ * `@binstruct/pppoe`, since the PPP protocol ID isn't part of the PPPoE
+ * header itself — it's the first two bytes of what PPPoE hands back as
+ * opaque `payload`.
+ *
+ * @returns A coder for {@linkcode PppoeSessionRefined} values.
+ */
+function pppFrame(): Coder<PppoeSessionRefined> {
+  return refineSwitch(
+    struct({ pppProtocol: u16be(), payload: bytes() }),
+    {
+      ipv4: refineFields({ payload: ipv4Frame() }),
+      ipv6: refineFields({ payload: ipv6Frame() }),
+      raw: refineFields({}),
+    },
+    {
+      refine: (host: PppHost): "ipv4" | "ipv6" | "raw" => {
+        switch (host.pppProtocol) {
+          case PPP_PROTOCOL_IPV4:
+            return "ipv4";
+          case PPP_PROTOCOL_IPV6:
+            return "ipv6";
+          default:
+            return "raw";
+        }
+      },
+      unrefine: (refined): "ipv4" | "ipv6" | "raw" => {
+        switch (refined.pppProtocol) {
+          case PPP_PROTOCOL_IPV4:
+            return "ipv4";
+          case PPP_PROTOCOL_IPV6:
+            return "ipv6";
+          default:
+            return "raw";
+        }
+      },
+    },
+  );
+}
+
+/** PPP frame with a typed IPv4 payload. */
+export type PppoeIpv4Frame = Omit<PppHost, "payload"> & {
+  payload: Ipv4Refined;
+};
+
+/** PPP frame with a typed IPv6 payload. */
+export type PppoeIpv6Frame = Omit<PppHost, "payload"> & {
+  payload: Ipv6Refined;
+};
+
+/**
+ * Refined PPP frame as carried inside a PPPoE Session payload — `payload`
+ * narrows by shape (IPv4 / IPv6 / raw bytes), dispatched by the PPP
+ * protocol ID.
+ */
+export type PppoeSessionRefined =
+  | PppoeIpv4Frame
+  | PppoeIpv6Frame
+  | PppHost;
+
+/**
+ * Creates a coder for a PPPoE Session-stage packet (`@binstruct/pppoe`)
+ * whose payload is the PPP protocol-ID mini-layer from {@linkcode pppFrame}.
+ *
+ * @returns A coder for {@linkcode PppoeSessionPacket} values.
+ */
+function pppoeSessionFrame(): Coder<PppoeSessionPacket> {
+  return refine(
+    pppoeHeader(),
+    refineFields({ payload: pppFrame() }),
+  )();
+}
+
+/** PPPoE Session-stage header whose payload is a typed PPP frame. */
+export type PppoeSessionPacket = Omit<PppoeHeader, "payload"> & {
+  payload: PppoeSessionRefined;
+};
+
+/**
+ * Host shape shared by every EtherType-space dispatch point this module
+ * builds: Ethernet II, Linux cooked capture (SLL), and — one level down — a
+ * VLAN tag's own encapsulated payload.
+ */
+type L3Payload = { payload: Uint8Array };
+
+/**
+ * Refiner arms shared by every EtherType-keyed dispatch point (Ethernet,
+ * SLL, and a VLAN tag's payload): IPv4, IPv6, ARP, PPPoE Discovery, PPPoE
+ * Session, and the raw fallback.
+ *
+ * VLAN nesting is deliberately **not** one of these arms — see
+ * {@linkcode vlanFrame}. Its recursion is bounded by an explicit depth
+ * parameter rather than being part of this shared, depth-agnostic set, so
+ * every caller adds its own "vlan" arm on top of what this returns.
+ */
+function l3Refiners<THost extends L3Payload>(): {
+  ipv4: Refiner<THost, Omit<THost, "payload"> & { payload: Ipv4Refined }, []>;
+  ipv6: Refiner<THost, Omit<THost, "payload"> & { payload: Ipv6Refined }, []>;
+  arp: Refiner<THost, Omit<THost, "payload"> & { payload: ArpData }, []>;
+  pppoeDiscovery: Refiner<
+    THost,
+    Omit<THost, "payload"> & { payload: PppoeHeader },
+    []
+  >;
+  pppoeSession: Refiner<
+    THost,
+    Omit<THost, "payload"> & { payload: PppoeSessionPacket },
+    []
+  >;
+  raw: Refiner<THost, THost, []>;
+} {
+  return {
+    ipv4: refineFields({ payload: ipv4Frame() }),
+    ipv6: refineFields({ payload: ipv6Frame() }),
+    arp: refineFields({ payload: arpData() }),
+    pppoeDiscovery: refineFields({ payload: pppoeHeader() }),
+    pppoeSession: refineFields({ payload: pppoeSessionFrame() }),
+    raw: refineFields({}),
+  };
+}
+
+type L3Key =
+  | "ipv4"
+  | "ipv6"
+  | "arp"
+  | "pppoeDiscovery"
+  | "pppoeSession"
+  | "raw";
+
+function classifyL3(etherType: number): L3Key {
+  switch (etherType) {
+    case ETHERTYPE_IPV4:
+      return "ipv4";
+    case ETHERTYPE_IPV6:
+      return "ipv6";
+    case ETHERTYPE_ARP:
+      return "arp";
+    case ETHERTYPE_PPPOE_DISCOVERY:
+      return "pppoeDiscovery";
+    case ETHERTYPE_PPPOE_SESSION:
+      return "pppoeSession";
+    default:
+      return "raw";
+  }
+}
+
+/**
+ * Creates a coder for an IEEE 802.1Q VLAN tag (`@binstruct/vlan`) whose
+ * encapsulated payload is dispatched by EtherType, with QinQ (double
+ * tagging) support bounded by `depth`.
+ *
+ * `depth` counts how many further nested VLAN tags this call is willing to
+ * unwrap: `1` (used at the true root, e.g. from {@linkcode inetFrame} and
+ * {@linkcode sllInetFrame}) allows one level of QinQ before the inner tag's
+ * own "vlan" arm is unavailable; `0` (used internally for that inner level)
+ * has no "vlan" arm in its own dispatch table at all, so a third stacked
+ * `0x8100` EtherType simply falls into the raw fallback instead of
+ * recursing further. This keeps the coder tree finite by construction —
+ * unlike VXLAN's tunnel back to `inetFrame()`, VLAN nesting needs no
+ * `lazy()` firebreak, since `depth` strictly decreases to `0` and stops.
+ *
+ * Hardcoding the nested call as `vlanFrame(1)` instead of `vlanFrame(0)`
+ * would silently reintroduce unbounded mutual recursion between this
+ * function and itself — and, unlike VXLAN, without a `lazy()` firebreak in
+ * place, so it would overflow the stack again at coder-build time rather
+ * than only misbehave at decode time.
+ *
+ * @param depth How many further levels of VLAN tagging to dispatch. `1`
+ *   allows one level of QinQ; `0` disables further VLAN dispatch, so a
+ *   nested tag surfaces as an undecoded {@linkcode VlanTag}.
+ * @returns A coder for {@linkcode VlanRefinedShallow} at `depth` `0`, or
+ *   {@linkcode VlanRefined} (one level of QinQ included) at `depth` `1`.
+ */
+export function vlanFrame(depth: 0): Coder<VlanRefinedShallow>;
+export function vlanFrame(depth: 1): Coder<VlanRefined>;
+export function vlanFrame(
+  depth: 0 | 1,
+): Coder<VlanRefinedShallow> | Coder<VlanRefined> {
+  if (depth === 0) {
+    return refineSwitch(
+      vlanTag(),
+      l3Refiners<VlanTag>(),
+      {
+        refine: (tag: VlanTag) => classifyL3(tag.etherType),
+        unrefine: (refined) => classifyL3(refined.etherType),
+      },
+    );
+  }
+
+  return refineSwitch(
+    vlanTag(),
+    {
+      ...l3Refiners<VlanTag>(),
+      vlan: refineFields({ payload: vlanFrame(0) }),
+    },
+    {
+      refine: (tag: VlanTag) => {
+        if (tag.etherType === TPID_8021Q) return "vlan";
+        return classifyL3(tag.etherType);
+      },
+      unrefine: (refined) => {
+        if (refined.etherType === TPID_8021Q) return "vlan";
+        return classifyL3(refined.etherType);
+      },
+    },
+  );
+}
+
+/** VLAN tag with a typed IPv4 payload. */
+export type VlanIpv4Frame = Omit<VlanTag, "payload"> & {
+  payload: Ipv4Refined;
+};
+
+/** VLAN tag with a typed IPv6 payload. */
+export type VlanIpv6Frame = Omit<VlanTag, "payload"> & {
+  payload: Ipv6Refined;
+};
+
+/** VLAN tag with a typed ARP payload. */
+export type VlanArpFrame = Omit<VlanTag, "payload"> & { payload: ArpData };
+
+/** VLAN tag with a typed PPPoE Discovery-stage payload. */
+export type VlanPppoeDiscoveryFrame = Omit<VlanTag, "payload"> & {
+  payload: PppoeHeader;
+};
+
+/** VLAN tag with a typed PPPoE Session-stage payload. */
+export type VlanPppoeSessionFrame = Omit<VlanTag, "payload"> & {
+  payload: PppoeSessionPacket;
+};
+
+/**
+ * Refined VLAN tag with no further VLAN dispatch available — `payload`
+ * narrows by shape (IPv4 / IPv6 / ARP / PPPoE Discovery / PPPoE Session /
+ * raw bytes). This is what {@linkcode vlanFrame}`(0)` produces: the inner
+ * tag of a QinQ pair, which does not itself dispatch a third stacked VLAN
+ * tag.
+ */
+export type VlanRefinedShallow =
+  | VlanIpv4Frame
+  | VlanIpv6Frame
+  | VlanArpFrame
+  | VlanPppoeDiscoveryFrame
+  | VlanPppoeSessionFrame
+  | VlanTag;
+
+/** VLAN tag carrying a single further nested (QinQ) VLAN tag. */
+export type VlanQinQFrame = Omit<VlanTag, "payload"> & {
+  payload: VlanRefinedShallow;
+};
+
+/**
+ * Refined VLAN tag — `payload` narrows by shape (IPv4 / IPv6 / ARP / PPPoE
+ * Discovery / PPPoE Session / one further nested VLAN tag / raw bytes),
+ * dispatched by the tag's own encapsulated EtherType. This is what
+ * {@linkcode vlanFrame}`(1)` produces, the depth used at every true root
+ * ({@linkcode inetFrame}, {@linkcode sllInetFrame}).
+ */
+export type VlanRefined = VlanQinQFrame | VlanRefinedShallow;
+
 /** Ethernet frame whose payload is a typed IPv4 datagram. */
 export type Ipv4Frame = Omit<Frame, "payload"> & { payload: Ipv4Refined };
+
+/** Ethernet frame whose payload is a typed IPv6 packet. */
+export type Ipv6Frame = Omit<Frame, "payload"> & { payload: Ipv6Refined };
 
 /** Ethernet frame whose payload is an Ethernet/IPv4 ARP packet. */
 export type ArpFrame = Omit<Frame, "payload"> & { payload: ArpData };
 
+/** Ethernet frame whose payload is a PPPoE Discovery-stage packet. */
+export type PppoeDiscoveryFrame = Omit<Frame, "payload"> & {
+  payload: PppoeHeader;
+};
+
+/** Ethernet frame whose payload is a PPPoE Session-stage packet. */
+export type PppoeSessionFrame = Omit<Frame, "payload"> & {
+  payload: PppoeSessionPacket;
+};
+
+/** Ethernet frame whose payload is a typed VLAN tag. */
+export type VlanFrame = Omit<Frame, "payload"> & { payload: VlanRefined };
+
 /**
  * Decoded Ethernet II frame as produced by {@link inetFrame}.
  *
- * The shape depends on `etherType` and (for IPv4) the inner `protocol`
- * field; narrow the union with property-existence checks (`"protocol" in
- * payload`, `"srcPort" in payload`, …) when reading. Frames whose tag has no
- * matching coder surface their `payload` as a raw `Uint8Array`.
+ * The shape depends on `etherType` and, for the layers it selects, further
+ * discriminator fields deeper in the stack; narrow the union with
+ * property-existence checks (`"protocol" in payload`, `"srcPort" in
+ * payload`, …) when reading. Frames whose tag has no matching coder surface
+ * their `payload` as a raw `Uint8Array`.
  */
-export type FrameRefined = Ipv4Frame | ArpFrame | Frame;
+export type FrameRefined =
+  | Ipv4Frame
+  | Ipv6Frame
+  | ArpFrame
+  | PppoeDiscoveryFrame
+  | PppoeSessionFrame
+  | VlanFrame
+  | Frame;
 
 /**
- * Creates a composed coder that walks an Ethernet II frame top-down,
- * dispatching the L3 payload by `etherType` and the L4 payload by IPv4's
- * `protocol`. Frames whose tag has no matching coder surface their payload
- * as a raw `Uint8Array`.
+ * Creates a composed coder that walks an Ethernet II frame
+ * (`@binstruct/ethernet`) top-down, dispatching the L2.5/L3 payload by
+ * `etherType` and every deeper layer by its own discriminator field. Frames
+ * whose tag has no matching coder surface their payload as a raw
+ * `Uint8Array`.
+ *
+ * @returns A coder for {@linkcode FrameRefined} values.
  */
 export function inetFrame(): Coder<FrameRefined> {
   return refineSwitch(
     ethernet2Frame(),
     {
-      ipv4: refineFields({ payload: ipv4Frame() }),
-      arp: refineFields({ payload: arpData() }),
-      raw: refineFields({}),
+      ...l3Refiners<Frame>(),
+      vlan: refineFields({ payload: vlanFrame(1) }),
     },
     {
-      refine: (frame: Frame): "ipv4" | "arp" | "raw" => {
-        switch (frame.etherType) {
-          case ETHERTYPE_IPV4:
-            return "ipv4";
-          case ETHERTYPE_ARP:
-            return "arp";
-          default:
-            return "raw";
-        }
+      refine: (frame: Frame) => {
+        if (frame.etherType === TPID_8021Q) return "vlan";
+        return classifyL3(frame.etherType);
       },
-      unrefine: (refined): "ipv4" | "arp" | "raw" => {
+      unrefine: (refined) => {
         if (refined.payload instanceof Uint8Array) return "raw";
-        switch (refined.etherType) {
-          case ETHERTYPE_IPV4:
-            return "ipv4";
-          case ETHERTYPE_ARP:
-            return "arp";
-          default:
-            return "raw";
-        }
+        if (refined.etherType === TPID_8021Q) return "vlan";
+        return classifyL3(refined.etherType);
+      },
+    },
+  );
+}
+
+/** Linux cooked capture (SLL) header whose payload is a typed IPv4 datagram. */
+export type SllIpv4Frame = Omit<SllHeader, "payload"> & {
+  payload: Ipv4Refined;
+};
+
+/** Linux cooked capture (SLL) header whose payload is a typed IPv6 packet. */
+export type SllIpv6Frame = Omit<SllHeader, "payload"> & {
+  payload: Ipv6Refined;
+};
+
+/** Linux cooked capture (SLL) header whose payload is an ARP packet. */
+export type SllArpFrame = Omit<SllHeader, "payload"> & { payload: ArpData };
+
+/** Linux cooked capture (SLL) header whose payload is a PPPoE Discovery-stage packet. */
+export type SllPppoeDiscoveryFrame = Omit<SllHeader, "payload"> & {
+  payload: PppoeHeader;
+};
+
+/** Linux cooked capture (SLL) header whose payload is a PPPoE Session-stage packet. */
+export type SllPppoeSessionFrame = Omit<SllHeader, "payload"> & {
+  payload: PppoeSessionPacket;
+};
+
+/** Linux cooked capture (SLL) header whose payload is a typed VLAN tag. */
+export type SllVlanFrame = Omit<SllHeader, "payload"> & {
+  payload: VlanRefined;
+};
+
+/**
+ * Decoded Linux cooked capture (SLL v1) header as produced by
+ * {@link sllInetFrame}. Mirrors {@linkcode FrameRefined} one layer down —
+ * SLL replaces the real link layer with its own fixed header, but dispatches
+ * through the exact same {@linkcode l3Refiners} arms via `protocol` in place
+ * of Ethernet's `etherType`.
+ */
+export type SllFrameRefined =
+  | SllIpv4Frame
+  | SllIpv6Frame
+  | SllArpFrame
+  | SllPppoeDiscoveryFrame
+  | SllPppoeSessionFrame
+  | SllVlanFrame
+  | SllHeader;
+
+/**
+ * Creates a composed coder that walks a Linux cooked capture (SLL v1)
+ * header (`@binstruct/sll`) top-down, dispatching the payload by `protocol`
+ * — the same EtherType-space dispatch {@link inetFrame} performs on
+ * Ethernet's `etherType`, reused here via {@linkcode l3Refiners}. Payloads
+ * whose tag has no matching coder surface as a raw `Uint8Array`.
+ *
+ * @returns A coder for {@linkcode SllFrameRefined} values.
+ */
+export function sllInetFrame(): Coder<SllFrameRefined> {
+  return refineSwitch(
+    sllHeader(),
+    {
+      ...l3Refiners<SllHeader>(),
+      vlan: refineFields({ payload: vlanFrame(1) }),
+    },
+    {
+      refine: (frame: SllHeader) => {
+        if (frame.protocol === TPID_8021Q) return "vlan";
+        return classifyL3(frame.protocol);
+      },
+      unrefine: (refined) => {
+        if (refined.payload instanceof Uint8Array) return "raw";
+        if (refined.protocol === TPID_8021Q) return "vlan";
+        return classifyL3(refined.protocol);
       },
     },
   );

--- a/packages/@binstruct/inet/mod.ts
+++ b/packages/@binstruct/inet/mod.ts
@@ -596,9 +596,9 @@ function classifyL3(etherType: number): L3Key {
  * @returns A coder for {@linkcode VlanRefinedShallow} at `depth` `0`, or
  *   {@linkcode VlanRefined} (one level of QinQ included) at `depth` `1`.
  */
-export function vlanFrame(depth: 0): Coder<VlanRefinedShallow>;
-export function vlanFrame(depth: 1): Coder<VlanRefined>;
-export function vlanFrame(
+function vlanFrame(depth: 0): Coder<VlanRefinedShallow>;
+function vlanFrame(depth: 1): Coder<VlanRefined>;
+function vlanFrame(
   depth: 0 | 1,
 ): Coder<VlanRefinedShallow> | Coder<VlanRefined> {
   if (depth === 0) {


### PR DESCRIPTION
Closes #212

Stacked on #214 (`feat(@hertzg/binstruct): add lazy coder for recursive structures`), base branch `feat/binstruct-lazy`. GitHub will retarget this PR to `main` automatically once #214 merges.

Wires the 19 protocol packages merged in #193-#211 into the `@binstruct/inet` encapsulation stack, plus a new `lazy()` coder primitive in `@hertzg/binstruct` needed to break the VXLAN <-> Ethernet build-time recursion cycle.

## Layering

- Ethernet root (`inetFrame()`) and a new SLL root (`sllInetFrame()`) share a generic `l3Refiners<THost>()` helper dispatching on a host discriminator field (etherType / protocol), never a payload-kind wrapper.
- VLAN/QinQ is depth-parameterized (`vlanFrame(depth: 0 | 1)`), internal to the module - bounded, not recursive, so it needs no `lazy()`.
- PPPoE session frames get an internal (unexported) PPP protocol-ID mini-layer dispatching to IPv4/IPv6.
- IPv4 gains IGMP and ESP arms; its UDP arm now dispatches further by port (VXLAN/NTP/BFD).
- IPv6 is wired as a new chain: TCP/UDP/ICMPv6/ESP.
- VXLAN's inner Ethernet frame is wrapped in `lazy(() => inetFrame())` since that arm is genuinely recursive (VXLAN -> Ethernet -> ... -> UDP -> VXLAN) and would otherwise blow the stack at coder-build time.
- Unknown discriminator values stay raw `Uint8Array` at every dispatch point.

## Explicitly out of scope

rtp, tls-record, and the file-format packages (mbr, tga, ico, mp3, sqlite, dos-mz, tar) are not wired in, per the issue.

## Breaking change

`Ipv4Packet`/`Ipv6Packet`'s UDP arm now widens `payload` from `UdpPacket` to the refined `UdpRefined` union (VXLAN/NTP/BFD/raw), so `Ipv4UdpPacket`/`Ipv6UdpPacket.payload` is no longer always a plain `UdpPacket`.

## Commits

- `feat(@binstruct/inet)!: wire vlan, pppoe, ipv6, igmp, esp, vxlan, ntp, bfd, sll into encapsulation stack` - the wiring itself, scoped to `@binstruct/inet` only.
- `fix(@binstruct/inet): unexport vlanFrame and add missing wiring test coverage` - review follow-up: keeps `vlanFrame` module-private like its sibling layer builders, and adds round-trip tests for the PPPoE Discovery, IPv6 ESP, and SLL-VLAN paths that had no direct coverage.

