### PR TITLE
feat(@hertzg/binstruct): add lazy coder for recursive structures

### DIFF
--- a/packages/@hertzg/binstruct/_deps.snap
+++ b/packages/@hertzg/binstruct/_deps.snap
@@ -11,6 +11,7 @@
     "./bytes": [],
     "./refine": [],
     "./ref": [],
+    "./lazy": [],
     "./helpers": []
   }
 }

--- a/packages/@hertzg/binstruct/deno.json
+++ b/packages/@hertzg/binstruct/deno.json
@@ -12,6 +12,7 @@
     "./bytes": "./bytes/bytes.ts",
     "./refine": "./refine/refine.ts",
     "./ref": "./ref/ref.ts",
+    "./lazy": "./lazy/lazy.ts",
     "./helpers": "./helpers.ts"
   },
   "types": "./mod.ts"

--- a/packages/@hertzg/binstruct/lazy/lazy.test.ts
+++ b/packages/@hertzg/binstruct/lazy/lazy.test.ts
@@ -1,0 +1,177 @@
+import { assertEquals } from "@std/assert";
+import { lazy } from "./lazy.ts";
+import { type Coder, type Context, createContext } from "../core.ts";
+import { u8be } from "../numeric/numeric.ts";
+import { refine } from "../refine/refine.ts";
+import { struct } from "../struct/struct.ts";
+import { bytes } from "../bytes/bytes.ts";
+
+Deno.test("lazy - round-trips like the coder it wraps", () => {
+  const inner = u8be();
+  const coder = lazy(() => inner);
+
+  const buffer = new Uint8Array(4);
+  const written = coder.encode(42, buffer);
+  const [decoded, read] = coder.decode(buffer);
+
+  const referenceBuffer = new Uint8Array(4);
+  const referenceWritten = inner.encode(42, referenceBuffer);
+  const [referenceDecoded, referenceRead] = inner.decode(referenceBuffer);
+
+  assertEquals(decoded, referenceDecoded);
+  assertEquals(written, referenceWritten);
+  assertEquals(read, referenceRead);
+});
+
+Deno.test("lazy - does not call the factory until first use", () => {
+  let builds = 0;
+  const coder = lazy(() => {
+    builds++;
+    return u8be();
+  });
+
+  assertEquals(builds, 0);
+
+  const buffer = new Uint8Array(4);
+  coder.encode(7, buffer);
+
+  assertEquals(builds, 1);
+});
+
+Deno.test("lazy - builds the inner coder at most once across many calls", () => {
+  let builds = 0;
+  const coder = lazy(() => {
+    builds++;
+    return u8be();
+  });
+
+  const buffer = new Uint8Array(4);
+  for (let i = 0; i < 5; i++) {
+    coder.encode(i, buffer);
+    coder.decode(buffer);
+  }
+
+  assertEquals(builds, 1);
+});
+
+Deno.test("lazy - shares a single context across nested encode/decode calls", () => {
+  const inner = struct({ a: u8be(), b: u8be() });
+  const coder = lazy(() => inner);
+
+  const buffer = new Uint8Array(4);
+  const value = { a: 1, b: 2 };
+
+  const encodeCtx = createContext("encode");
+  const written = coder.encode(value, buffer, encodeCtx);
+
+  const decodeCtx = createContext("decode");
+  const [decoded, read] = coder.decode(buffer, decodeCtx);
+
+  assertEquals(decoded, value);
+  assertEquals(written, read);
+});
+
+interface Frame {
+  hasNext: 0 | 1;
+  rest: Frame | Uint8Array;
+}
+
+interface FrameHost {
+  hasNext: 0 | 1;
+  rest: Uint8Array;
+}
+
+// `lazyFrame` closes the cycle: it's created before `frameCoder` exists, but
+// its factory (`() => frameCoder`) isn't invoked until the first
+// encode/decode, by which point `frameCoder`'s own initializer has finished.
+const lazyFrame: Coder<Frame> = lazy(() => frameCoder);
+
+// `rest` is a greedy `bytes()` field, so it always consumes everything left
+// in the view it's handed. Encoding first (to learn the exact byte count)
+// and then decoding only that exact slice keeps every level self-delimiting
+// without needing an explicit length field.
+const frameCoder: Coder<Frame> = refine(
+  struct({ hasNext: u8be() as unknown as Coder<0 | 1>, rest: bytes() }),
+  {
+    refine: (host: FrameHost, ctx: Context): Frame => {
+      if (host.hasNext === 0) {
+        return { hasNext: 0, rest: host.rest };
+      }
+      const [rest] = lazyFrame.decode(host.rest, ctx);
+      return { hasNext: 1, rest };
+    },
+    unrefine: (frame: Frame, ctx: Context): FrameHost => {
+      if (frame.hasNext === 0) {
+        return { hasNext: 0, rest: frame.rest as Uint8Array };
+      }
+      const scratch = new Uint8Array(1024);
+      const bytesWritten = lazyFrame.encode(
+        frame.rest as Frame,
+        scratch,
+        ctx,
+      );
+      return { hasNext: 1, rest: scratch.subarray(0, bytesWritten) };
+    },
+  },
+)();
+
+Deno.test("lazy - self-referential graph round-trips through multiple levels", () => {
+  const value: Frame = {
+    hasNext: 1,
+    rest: {
+      hasNext: 1,
+      rest: {
+        hasNext: 0,
+        rest: new Uint8Array(0),
+      },
+    },
+  };
+
+  const buffer = new Uint8Array(16);
+  const written = frameCoder.encode(value, buffer);
+  const [decoded, read] = frameCoder.decode(buffer.subarray(0, written));
+
+  assertEquals(decoded, value);
+  assertEquals(written, read);
+});
+
+Deno.test("lazy - self-referential graph round-trips a single leaf", () => {
+  const value: Frame = { hasNext: 0, rest: new Uint8Array(0) };
+
+  const buffer = new Uint8Array(16);
+  const written = frameCoder.encode(value, buffer);
+  const [decoded, read] = frameCoder.decode(buffer.subarray(0, written));
+
+  assertEquals(decoded, value);
+  assertEquals(written, read);
+});
+
+interface Ping {
+  kind: 0;
+  next: Pong;
+}
+interface Pong {
+  kind: 1;
+  ttl: number;
+}
+
+Deno.test("lazy - breaks a build-time cycle between two struct coders", () => {
+  const pingCoder: Coder<Ping> = struct({
+    kind: u8be() as unknown as Coder<0>,
+    next: lazy(() => pongCoder),
+  });
+
+  const pongCoder: Coder<Pong> = struct({
+    kind: u8be() as unknown as Coder<1>,
+    ttl: u8be(),
+  });
+
+  const value: Ping = { kind: 0, next: { kind: 1, ttl: 64 } };
+  const buffer = new Uint8Array(8);
+
+  const written = pingCoder.encode(value, buffer);
+  const [decoded, read] = pingCoder.decode(buffer);
+
+  assertEquals(decoded, value);
+  assertEquals(written, read);
+});

--- a/packages/@hertzg/binstruct/lazy/lazy.ts
+++ b/packages/@hertzg/binstruct/lazy/lazy.ts
@@ -1,0 +1,139 @@
+/**
+ * Lazily-built coder for mutually-recursive coder graphs.
+ *
+ * `lazy()` defers calling its `factory` until the first `encode`/`decode`,
+ * then caches the result forever. This breaks the build-time recursion that
+ * happens when two or more coders reference each other (`a` needs `b`, `b`
+ * needs `a`): without `lazy()`, building either one eagerly walks into the
+ * other before it has a value to return, and JavaScript's temporal dead zone
+ * turns that into a `ReferenceError` (or, if the cycle is expressed through
+ * a factory function instead of a `const`, an unbounded `RangeError: Maximum
+ * call stack size exceeded`).
+ *
+ * `lazy()` does not bound *runtime* recursion. Decoding a self-referential
+ * structure still recurses once per level actually present in the input;
+ * termination is the protocol's job (a discriminator that stops matching, or
+ * the buffer running out), not `lazy()`'s.
+ *
+ * @example Breaking a build-time cycle between two struct coders
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { struct, lazy, type Coder } from "@hertzg/binstruct";
+ * import { u8 } from "@hertzg/binstruct/numeric";
+ *
+ * interface Ping {
+ *   kind: 0;
+ *   next: Pong;
+ * }
+ * interface Pong {
+ *   kind: 1;
+ *   ttl: number;
+ * }
+ *
+ * // `pingCoder` needs `pongCoder` while building its own `next` field, but
+ * // `pongCoder` is declared afterwards and does not exist yet at that point.
+ * // Without `lazy()` this is a ReferenceError (reading `pongCoder` inside
+ * // its own temporal dead zone) once the graph grows past two coders and
+ * // closes an actual cycle, as it does for tunneling protocols.
+ * const pingCoder: Coder<Ping> = struct({
+ *   kind: u8() as unknown as Coder<0>,
+ *   next: lazy(() => pongCoder),
+ * });
+ *
+ * const pongCoder: Coder<Pong> = struct({
+ *   kind: u8() as unknown as Coder<1>,
+ *   ttl: u8(),
+ * });
+ *
+ * const buffer = new Uint8Array(8);
+ * const value: Ping = { kind: 0, next: { kind: 1, ttl: 64 } };
+ *
+ * const written = pingCoder.encode(value, buffer);
+ * const [decoded, read] = pingCoder.decode(buffer);
+ *
+ * assertEquals(decoded, value);
+ * assertEquals(written, read);
+ * ```
+ *
+ * @module
+ */
+
+import { type Coder, createContext, kCoderKind } from "../core.ts";
+import { refSetValue } from "../ref/ref.ts";
+
+const kKindLazy = Symbol("lazy");
+
+/**
+ * Wraps a coder factory so the coder it produces is built on first use
+ * instead of when `lazy()` is called, and only ever built once.
+ *
+ * Use this to close mutually-recursive coder graphs — for example a
+ * tunneling protocol whose payload can itself contain the outer protocol
+ * (VXLAN carrying Ethernet carrying IPv4 carrying UDP carrying VXLAN again).
+ * Writing that graph with plain `const`s is impossible: whichever coder is
+ * declared last needs the first one, which is still in its temporal dead
+ * zone. Wrapping the back-reference in `lazy(() => firstCoder)` defers
+ * reading `firstCoder` until an `encode`/`decode` call actually happens,
+ * by which point every top-level `const` in the module has been assigned.
+ *
+ * The factory is called at most once. Its result is cached and reused for
+ * every subsequent `encode`/`decode` on this `lazy()` coder, so building the
+ * inner coder graph (e.g. calling `struct()`/`refineSwitch()`) is not
+ * repeated per call.
+ *
+ * @template TDecoded - The type of the value the inner coder decodes to.
+ * @param factory - Builds the inner coder. Called at most once, on first
+ *   `encode` or `decode`.
+ * @returns A `Coder<TDecoded>` that transparently delegates to the coder
+ *   `factory` builds.
+ *
+ * @example Deferring construction until first use
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { lazy } from "@hertzg/binstruct/lazy";
+ * import { u16le } from "@hertzg/binstruct/numeric";
+ *
+ * let builds = 0;
+ * const coder = lazy(() => {
+ *   builds++;
+ *   return u16le();
+ * });
+ *
+ * assertEquals(builds, 0); // not built yet
+ *
+ * const buffer = new Uint8Array(4);
+ * coder.encode(513, buffer);
+ * coder.decode(buffer);
+ * coder.encode(7, buffer);
+ *
+ * assertEquals(builds, 1); // built once, then memoized
+ * ```
+ */
+export function lazy<TDecoded>(
+  factory: () => Coder<TDecoded>,
+): Coder<TDecoded> {
+  let inner: Coder<TDecoded> | undefined;
+  const resolve = (): Coder<TDecoded> => {
+    if (inner === undefined) {
+      inner = factory();
+    }
+    return inner;
+  };
+
+  let self: Coder<TDecoded>;
+  return self = {
+    [kCoderKind]: kKindLazy,
+    encode: (decoded, target, context) => {
+      const ctx = context ?? createContext("encode");
+      const bytesWritten = resolve().encode(decoded, target, ctx);
+      refSetValue(ctx, self, decoded);
+      return bytesWritten;
+    },
+    decode: (encoded, context) => {
+      const ctx = context ?? createContext("decode");
+      const [decoded, bytesRead] = resolve().decode(encoded, ctx);
+      refSetValue(ctx, self, decoded);
+      return [decoded, bytesRead];
+    },
+  };
+}

--- a/packages/@hertzg/binstruct/mod.ts
+++ b/packages/@hertzg/binstruct/mod.ts
@@ -52,6 +52,9 @@
  * ### Buffer Management
  * - {@link autoGrowBuffer}: Automatically grow buffers during encoding operations
  *
+ * ### Lazy Construction
+ * - {@link lazy}: Defer building a coder until first use, for mutually-recursive coder graphs
+ *
  * ### Helper Functions
  * - {@link encode}: Simplified encoding with automatic buffer allocation
  * - {@link decode}: Simplified decoding that returns only the decoded value
@@ -65,6 +68,7 @@
  * - [`buffer`](https://jsr.io/@hertzg/binstruct/doc/buffer): Buffer helpers like {@link autoGrowBuffer}
  * - [`bytes`](https://jsr.io/@hertzg/binstruct/doc/bytes): Raw byte slice coders via {@link bytes}
  * - [`helpers`](https://jsr.io/@hertzg/binstruct/doc/helpers): High-level {@link encode} / {@link decode}
+ * - [`lazy`](https://jsr.io/@hertzg/binstruct/doc/lazy): Deferred coder construction via {@link lazy}
  * - [`numeric`](https://jsr.io/@hertzg/binstruct/doc/numeric): Numeric coder factories such as {@link u32le}
  * - [`ref`](https://jsr.io/@hertzg/binstruct/doc/ref): Reference primitives ({@link ref}, {@link computedRef}, {@link isRef})
  * - [`refine`](https://jsr.io/@hertzg/binstruct/doc/refine): Refinement utilities ({@link refine}, {@link refineSwitch})
@@ -393,3 +397,4 @@ export * from "./bits/bit-struct.ts";
 export * from "./refine/refine.ts";
 export * from "./helpers.ts";
 export * from "./buffer.ts";
+export * from "./lazy/lazy.ts";


### PR DESCRIPTION
## Why

Coder graphs are built eagerly: composing `struct()`/`refineSwitch()` calls walks
the whole tree at construction time, before any bytes are parsed. That's a
problem for a cycle like VXLAN carrying Ethernet carrying IPv4 carrying UDP
carrying VXLAN again — building such a graph eagerly recurses forever and never
finishes.

`lazy(factory)` breaks the cycle by returning a placeholder coder that defers
calling `factory()` until the first `encode`/`decode`, and memoizes the result
so later calls reuse the same inner coder. This only cuts the *build-time*
cycle; it does not bound *runtime* recursion — the packet's own bytes still
have to terminate the nesting, same as any other recursive parse.

The placeholder forwards the context through to the inner coder so `ref()`
still works across the `lazy()` boundary, and registers its decoded value in
context the same way the inner coder would, so later fields can `ref()` the
lazy field like any other.

## Stacking

This is extracted from #213, which now stacks on top of this PR (base branch
`feat/binstruct-lazy`). #213 needs `lazy()` to wire the VXLAN/Ethernet/IPv4
encapsulation cycle without an infinite build-time recursion.
