### PR TITLE
fix(@hertzg/ip, @hertzg/crc, @hertzg/mymagti-api): document public symbols for jsr score

### DIFF
--- a/packages/@hertzg/crc/mod.ts
+++ b/packages/@hertzg/crc/mod.ts
@@ -34,34 +34,55 @@
  */
 
 export {
+  /** Calculates CRC8 checksum for the given data, using CRC8-Maxim by default. */
   crc8,
+  /** CRC8-CCITT polynomial (ATM HEC). */
   CRC8_CCITT_POLYNOMIAL,
+  /** CRC8-Maxim/Dallas polynomial (1-Wire, iButton). */
   CRC8_MAXIM_POLYNOMIAL,
+  /** Creates a CRC8 function for the given polynomial. */
   createCrc8,
+  /** Memoized version of createCrc8. */
   memoizedCreateCrc8,
 } from "./crc8.ts";
 
 export {
+  /** Calculates CRC16 checksum for the given data, using CRC16-CCITT by default. */
   crc16,
+  /** CRC16-CCITT polynomial (X.25, HDLC, Bluetooth). */
   CRC16_CCITT_POLYNOMIAL,
+  /** CRC16-IBM/ANSI polynomial (USB, Modbus). */
   CRC16_IBM_POLYNOMIAL,
+  /** Creates a CRC16 function for the given polynomial. */
   createCrc16,
+  /** Memoized version of createCrc16. */
   memoizedCreateCrc16,
 } from "./crc16.ts";
 
 export {
+  /** Calculates CRC32 checksum for the given data, using the standard CRC32 polynomial by default. */
   crc32,
+  /** Standard CRC32 polynomial (ISO 3309, PNG, ZIP, gzip). */
   CRC32_POLYNOMIAL,
+  /** CRC32C polynomial (iSCSI, SCTP, ext4). Also known as Castagnoli. */
   CRC32C_POLYNOMIAL,
+  /** CRC32K polynomial (Koopman). Designed for improved Hamming-distance coverage. */
   CRC32K_POLYNOMIAL,
+  /** Creates a CRC32 function for the given polynomial. */
   createCrc32,
+  /** Memoized version of createCrc32. */
   memoizedCreateCrc32,
 } from "./crc32.ts";
 
 export {
+  /** Calculates CRC64 checksum for the given data, using CRC64-ECMA by default. */
   crc64,
+  /** CRC64-ECMA polynomial (XZ, 7z). */
   CRC64_ECMA_POLYNOMIAL,
+  /** CRC64-ISO polynomial (ISO 3309). */
   CRC64_ISO_POLYNOMIAL,
+  /** Creates a CRC64 function for the given polynomial. */
   createCrc64,
+  /** Memoized version of createCrc64. */
   memoizedCreateCrc64,
 } from "./crc64.ts";

--- a/packages/@hertzg/ip/cidr.ts
+++ b/packages/@hertzg/ip/cidr.ts
@@ -59,8 +59,14 @@ import {
   stringifyCidrv6,
 } from "./cidrv6.ts";
 
-export type { Cidrv4 } from "./cidrv4.ts";
-export type { Cidrv6 } from "./cidrv6.ts";
+export type {
+  /** Type representing an IPv4 CIDR block. */
+  Cidrv4,
+} from "./cidrv4.ts";
+export type {
+  /** Type representing an IPv6 CIDR block. */
+  Cidrv6,
+} from "./cidrv6.ts";
 
 /**
  * A CIDR block of either IP version.
@@ -221,6 +227,7 @@ export function cidrContainsCidr<T extends Cidr>(
   outer: T,
   inner: T,
 ): boolean;
+/** Checks if one CIDR block fully contains another. */
 export function cidrContainsCidr(outer: Cidr, inner: Cidr): boolean {
   if (isCidrv6(outer) && isCidrv6(inner)) {
     return cidrv6ContainsCidr(outer, inner);
@@ -282,6 +289,7 @@ export function cidrOverlaps<T extends Cidr>(
   a: T,
   b: T,
 ): boolean;
+/** Checks if two CIDR blocks overlap (share at least one address). */
 export function cidrOverlaps(a: Cidr, b: Cidr): boolean {
   if (isCidrv6(a) && isCidrv6(b)) {
     return cidrv6Overlaps(a, b);
@@ -337,6 +345,7 @@ export function cidrIntersect<T extends Cidr>(
   a: T,
   b: T,
 ): T | null;
+/** Returns the intersection of two CIDR blocks. */
 export function cidrIntersect(a: Cidr, b: Cidr): Cidr | null {
   if (isCidrv6(a) && isCidrv6(b)) {
     return cidrv6Intersect(a, b);
@@ -391,6 +400,7 @@ export function cidrSubtract<T extends Cidr>(
   a: T,
   b: T,
 ): T[];
+/** Subtracts one CIDR block from another. */
 export function cidrSubtract(a: Cidr, b: Cidr): Cidr[] {
   if (isCidrv6(a) && isCidrv6(b)) {
     return cidrv6Subtract(a, b);
@@ -440,6 +450,7 @@ export function cidrSubtract(a: Cidr, b: Cidr): Cidr[] {
 export function cidrMerge<T extends Cidr>(
   cidrs: readonly T[],
 ): T[];
+/** Merges CIDR blocks into the minimal covering set. */
 export function cidrMerge(cidrs: readonly Cidr[]): Cidr[] {
   if (cidrs.length === 0) {
     return [];
@@ -475,6 +486,7 @@ export function cidrMerge(cidrs: readonly Cidr[]): Cidr[] {
 export function cidrSize<T extends Cidr>(
   cidr: T,
 ): T extends Cidrv6 ? bigint : number;
+/** Returns the total number of addresses in a CIDR block. */
 export function cidrSize(cidr: Cidr): number | bigint {
   if (isCidrv6(cidr)) {
     return cidrv6Size(cidr);
@@ -526,6 +538,7 @@ export function cidrAddresses(
     step?: number | bigint;
   },
 ): Generator<number | bigint>;
+/** Generates IP addresses within a CIDR block. */
 export function* cidrAddresses(
   cidr: Cidr,
   options?: {

--- a/packages/@hertzg/ip/cidrv4.ts
+++ b/packages/@hertzg/ip/cidrv4.ts
@@ -357,6 +357,7 @@ export function cidrv4Size(prefixLength: number): number;
  * @returns The total number of addresses
  */
 export function cidrv4Size(cidrOrPrefixLength: Cidrv4 | number): number;
+/** Returns the total number of IP addresses for either a CIDR block or a prefix length. */
 export function cidrv4Size(cidrOrPrefixLength: Cidrv4 | number): number {
   const prefixLength = typeof cidrOrPrefixLength === "number"
     ? cidrOrPrefixLength

--- a/packages/@hertzg/ip/cidrv6.ts
+++ b/packages/@hertzg/ip/cidrv6.ts
@@ -322,6 +322,7 @@ export function cidrv6Size(prefixLength: number): bigint;
  * @returns The total number of addresses as a bigint
  */
 export function cidrv6Size(cidrOrPrefixLength: Cidrv6 | number): bigint;
+/** Returns the total number of IP addresses for either a CIDR block or a prefix length. */
 export function cidrv6Size(cidrOrPrefixLength: Cidrv6 | number): bigint {
   const prefixLength = typeof cidrOrPrefixLength === "number"
     ? cidrOrPrefixLength

--- a/packages/@hertzg/ip/classify.ts
+++ b/packages/@hertzg/ip/classify.ts
@@ -42,16 +42,15 @@
  */
 
 import { parseIp } from "./ip.ts";
-import {
-  classifyIpv4,
-  type ClassificationIpv4,
-} from "./classifyv4.ts";
-import {
-  classifyIpv6,
-  type ClassificationIpv6,
-} from "./classifyv6.ts";
+import { type ClassificationIpv4, classifyIpv4 } from "./classifyv4.ts";
+import { type ClassificationIpv6, classifyIpv6 } from "./classifyv6.ts";
 
-export type { ClassificationIpv4, ClassificationIpv6 };
+export type {
+  /** Type for all IPv4 classification labels. */
+  ClassificationIpv4,
+  /** Type for all IPv6 classification labels. */
+  ClassificationIpv6,
+};
 
 /**
  * Result of classifying an IPv4 address.
@@ -209,6 +208,7 @@ export function classifyIp(ip: string): ClassifiedIp;
  * ```
  */
 export function classifyIp(ip: number | bigint): ClassifiedIp;
+/** Classifies an IPv4 or IPv6 address, or parses and classifies an IP address string. */
 export function classifyIp(ip: number | bigint | string): ClassifiedIp {
   if (typeof ip === "string") {
     return classifyIp(parseIp(ip));

--- a/packages/@hertzg/ip/ip.ts
+++ b/packages/@hertzg/ip/ip.ts
@@ -112,6 +112,7 @@ export function stringifyIp(ip: number): string;
 export function stringifyIp(ip: bigint): string;
 /** Stringifies an IPv4 or IPv6 address to its standard notation. */
 export function stringifyIp(ip: number | bigint): string;
+/** Stringifies an IPv4 or IPv6 address to its standard notation. */
 export function stringifyIp(ip: number | bigint): string {
   if (typeof ip === "bigint") {
     return stringifyIpv6(ip);

--- a/packages/@hertzg/ip/mod.ts
+++ b/packages/@hertzg/ip/mod.ts
@@ -313,19 +313,36 @@ import { parseIp, stringifyIp } from "./ip.ts";
 import type { Cidrv4 } from "./cidr.ts";
 import type { Cidrv6 } from "./cidr.ts";
 
-export { parseIp, stringifyIp } from "./ip.ts";
 export {
+  /** Parse any IP address string to number (IPv4) or bigint (IPv6). */
+  parseIp,
+  /** Convert number or bigint to IP address string. */
+  stringifyIp,
+} from "./ip.ts";
+export {
+  /** A CIDR block of either IP version. */
   type Cidr,
+  /** Generate IP addresses in a CIDR block. */
   cidrAddresses,
+  /** Check if one CIDR fully contains another. */
   cidrContainsCidr,
+  /** Return the overlapping CIDR block, or null. */
   cidrIntersect,
+  /** Merge CIDR blocks into the minimal covering set. */
   cidrMerge,
+  /** Check if two CIDRs share at least one address. */
   cidrOverlaps,
+  /** Get total number of addresses in a CIDR block. */
   cidrSize,
+  /** Return CIDR blocks in A but not in B. */
   cidrSubtract,
+  /** Type guard that checks whether a Cidr is an IPv4 CIDR block. */
   isCidrv4,
+  /** Type guard that checks whether a Cidr is an IPv6 CIDR block. */
   isCidrv6,
+  /** Parse any CIDR notation string to Cidrv4 or Cidrv6. */
   parseCidr,
+  /** Convert Cidrv4 or Cidrv6 to CIDR notation string. */
   stringifyCidr,
 } from "./cidr.ts";
 
@@ -405,6 +422,7 @@ export function stringify(value: Cidrv6): string;
  * ```
  */
 export function stringify(value: number | bigint | Cidrv4 | Cidrv6): string;
+/** Stringifies an IP address or CIDR block to its standard notation. */
 export function stringify(value: number | bigint | Cidrv4 | Cidrv6): string {
   if (typeof value === "number" || typeof value === "bigint") {
     return stringifyIp(value);
@@ -412,97 +430,191 @@ export function stringify(value: number | bigint | Cidrv4 | Cidrv6): string {
   return stringifyCidr(value);
 }
 export {
+  /** Type for all IPv4 classification labels. */
   type ClassificationIpv4,
+  /** Type for all IPv6 classification labels. */
   type ClassificationIpv6,
+  /** Discriminated union result with kind, value, and classification. */
   type ClassifiedIp,
+  /** Result type for IPv4 classification. */
   type ClassifiedIpv4,
+  /** Result type for IPv6 classification. */
   type ClassifiedIpv6,
+  /** Classify an IPv4 (number) or IPv6 (bigint) address. */
   classifyIp,
 } from "./classify.ts";
-export { isValidCidr, isValidIp } from "./validate.ts";
+export {
+  /** Check if a string is valid CIDR notation (IPv4 or IPv6). */
+  isValidCidr,
+  /** Check if a string is a valid plain IP address (IPv4 or IPv6). */
+  isValidIp,
+} from "./validate.ts";
 
 // --- IPv4 ---
 
-export { parseIpv4, stringifyIpv4 } from "./ipv4.ts";
-export { isValidCidrv4, isValidIpv4 } from "./validatev4.ts";
+export {
+  /** Parse dotted decimal notation to number. */
+  parseIpv4,
+  /** Convert number to dotted decimal notation. */
+  stringifyIpv4,
+} from "./ipv4.ts";
+export {
+  /** Check if a string is valid IPv4 CIDR notation. */
+  isValidCidrv4,
+  /** Check if a string is a valid IPv4 address. */
+  isValidIpv4,
+} from "./validatev4.ts";
 
 export {
+  /** Type representing an IPv4 CIDR block. */
   type Cidrv4,
+  /** Generate IP addresses in CIDR range. */
   cidrv4Addresses,
+  /** Alias for cidrv4LastAddress. */
   cidrv4BroadcastAddress,
+  /** Check if IP is within CIDR range. */
   cidrv4Contains,
+  /** Check if one IPv4 CIDR fully contains another. */
   cidrv4ContainsCidr,
+  /** Get first address in CIDR range. */
   cidrv4FirstAddress,
+  /** Return the overlapping IPv4 CIDR block, or null. */
   cidrv4Intersect,
+  /** Get last address in CIDR range. */
   cidrv4LastAddress,
+  /** Create network mask from prefix length (0-32). */
   cidrv4Mask,
+  /** Merge IPv4 CIDR blocks into the minimal covering set. */
   cidrv4Merge,
+  /** Alias for cidrv4FirstAddress. */
   cidrv4NetworkAddress,
+  /** Check if two IPv4 CIDRs share at least one address. */
   cidrv4Overlaps,
+  /** Get total number of addresses in CIDR range. */
   cidrv4Size,
+  /** Return IPv4 CIDR blocks in A but not in B. */
   cidrv4Subtract,
+  /** Parse CIDR notation string to Cidrv4. */
   parseCidrv4,
+  /** Convert Cidrv4 to CIDR notation string. */
   stringifyCidrv4,
 } from "./cidrv4.ts";
 
 export {
+  /** Classify an IPv4 address into its well-known range. */
   classifyIpv4,
+  /** Check if address is benchmarking (198.18.0.0/15). */
   isIpv4Benchmarking,
+  /** Check if address is broadcast (255.255.255.255). */
   isIpv4Broadcast,
+  /** Check if address is Carrier-Grade NAT (100.64.0.0/10). */
   isIpv4CgNat,
+  /** Check if address is documentation (RFC 5737). */
   isIpv4Documentation,
+  /** Check if address is link-local (169.254.0.0/16). */
   isIpv4LinkLocal,
+  /** Check if address is loopback (127.0.0.0/8). */
   isIpv4Loopback,
+  /** Check if address is multicast (224.0.0.0/4). */
   isIpv4Multicast,
+  /** Check if address is private (RFC 1918). */
   isIpv4Private,
+  /** Check if address is publicly routable. */
   isIpv4Public,
+  /** Check if address is reserved (240.0.0.0/4). */
   isIpv4Reserved,
+  /** Check if address is "this network" (0.0.0.0/8). */
   isIpv4ThisNetwork,
 } from "./classifyv4.ts";
 
 // --- IPv6 ---
 
-export { compressIpv6, expandIpv6, parseIpv6, stringifyIpv6 } from "./ipv6.ts";
-export { isValidCidrv6, isValidIpv6 } from "./validatev6.ts";
+export {
+  /** Compress to canonical shortest form. */
+  compressIpv6,
+  /** Expand to full uncompressed form. */
+  expandIpv6,
+  /** Parse colon-hexadecimal notation to bigint. */
+  parseIpv6,
+  /** Convert bigint to compressed colon-hexadecimal. */
+  stringifyIpv6,
+} from "./ipv6.ts";
+export {
+  /** Check if a string is valid IPv6 CIDR notation. */
+  isValidCidrv6,
+  /** Check if a string is a valid IPv6 address. */
+  isValidIpv6,
+} from "./validatev6.ts";
 
 export {
+  /** Type representing an IPv6 CIDR block. */
   type Cidrv6,
+  /** Generate IP addresses in CIDR range. */
   cidrv6Addresses,
+  /** Check if IP is within CIDR range. */
   cidrv6Contains,
+  /** Check if one IPv6 CIDR fully contains another. */
   cidrv6ContainsCidr,
+  /** Get first address in CIDR range. */
   cidrv6FirstAddress,
+  /** Return the overlapping IPv6 CIDR block, or null. */
   cidrv6Intersect,
+  /** Get last address in CIDR range. */
   cidrv6LastAddress,
+  /** Create network mask from prefix length (0-128). */
   cidrv6Mask,
+  /** Merge IPv6 CIDR blocks into the minimal covering set. */
   cidrv6Merge,
+  /** Check if two IPv6 CIDRs share at least one address. */
   cidrv6Overlaps,
+  /** Get total number of addresses in CIDR range. */
   cidrv6Size,
+  /** Return IPv6 CIDR blocks in A but not in B. */
   cidrv6Subtract,
+  /** Parse CIDR notation string to Cidrv6. */
   parseCidrv6,
+  /** Convert Cidrv6 to CIDR notation string. */
   stringifyCidrv6,
 } from "./cidrv6.ts";
 
 export {
+  /** Classify an IPv6 address into its well-known range. */
   classifyIpv6,
+  /** Check if address is benchmarking (2001:2::/48). */
   isIpv6Benchmarking,
+  /** Check if address is documentation (2001:db8::/32). */
   isIpv6Documentation,
+  /** Check if address is global unicast (2000::/3). */
   isIpv6GlobalUnicast,
+  /** Check if address is IPv4-mapped (::ffff:0:0/96). */
   isIpv6Ipv4Mapped,
+  /** Check if address is IPv4-translated (64:ff9b::/96). */
   isIpv6Ipv4Translated,
+  /** Check if address is link-local (fe80::/10). */
   isIpv6LinkLocal,
+  /** Check if address is loopback (::1). */
   isIpv6Loopback,
+  /** Check if address is multicast (ff00::/8). */
   isIpv6Multicast,
+  /** Check if address is ORCHIDv2 (2001:20::/28). */
   isIpv6Orchidv2,
+  /** Check if address is Teredo (2001::/32). */
   isIpv6Teredo,
+  /** Check if address is unique local (fc00::/7). */
   isIpv6UniqueLocal,
+  /** Check if address is unspecified (::). */
   isIpv6Unspecified,
 } from "./classifyv6.ts";
 
 // --- IPv4-mapped IPv6 conversion ---
 
 export {
+  /** Convert IPv4-mapped IPv6 CIDR to IPv4 CIDR. */
   cidrv4FromCidrv64Mapped,
+  /** Convert IPv4 CIDR to IPv4-mapped IPv6 CIDR. */
   cidrv4ToCidrv64Mapped,
+  /** Extract IPv4 number from IPv4-mapped IPv6 bigint. */
   ipv4From64Mapped,
+  /** Convert IPv4 number to IPv4-mapped IPv6 bigint. */
   ipv4To64Mapped,
 } from "./4to6.ts";

--- a/packages/@hertzg/mymagti-api/mod.ts
+++ b/packages/@hertzg/mymagti-api/mod.ts
@@ -1,1 +1,42 @@
+/**
+ * Client for the MyMagti API.
+ *
+ * Currently provides {@link fetchToken} and the other OAuth helpers for
+ * obtaining and refreshing OAuth tokens by mimicking the mobile app
+ * requests. You can swap the fetch implementation for testing.
+ *
+ * @example Mocking fetch for tests
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { fetchToken } from "@hertzg/mymagti-api";
+ *
+ * const mockFetch: typeof fetch = async (_url, _init) => new Response(
+ *   JSON.stringify({
+ *     access_token: "A",
+ *     autoLogin: 0,
+ *     expires_in: 3600,
+ *     jti: "id",
+ *     phoneNo: "5xxxxxxxx",
+ *     refresh_token: "R",
+ *     scope: "*",
+ *     token_type: "bearer",
+ *     userId: 1,
+ *     userIdentifier: "u",
+ *   }),
+ *   { status: 200, headers: { "content-type": "application/json" } },
+ * );
+ *
+ * const res = await fetchToken(
+ *   { type: "login", username: "u", password: "p" },
+ *   { fetch: mockFetch },
+ * );
+ *
+ * assertEquals(res.result, "success");
+ * if (res.result === "success") {
+ *   assertEquals(typeof res.data.access_token, "string");
+ * }
+ * ```
+ *
+ * @module
+ */
 export * from "./oauth/oauth.ts";


### PR DESCRIPTION
## Summary

Raises `percentageDocumentedSymbols` / `hasReadme` / `hasReadmeExamples` / `allEntrypointsDocs` for three packages by filling documentation gaps only — no runtime behavior, signatures, or exports changed.

### @hertzg/ip — `percentageDocumentedSymbols` 0.456 → 1.0
JSR computes documentation coverage per declaration reachable from each `deno.json` entrypoint, including barrel re-exports in `mod.ts` and overload implementation signatures — not just the "canonical" declaration in the source file. `mod.ts` re-exports ~90 symbols via `export { name, ... } from "./file.ts"` without per-specifier doc comments, so JSR counted every one of them as undocumented even though the original declarations were already fully documented. Added a one-line JSDoc comment above each re-exported specifier (inside the `export { ... }` braces, which is where deno_doc actually attaches it), plus doc comments on the handful of dispatcher-function implementation signatures in `cidr.ts`, `cidrv4.ts`, `cidrv6.ts`, `classify.ts`, and `ip.ts` that had overload signatures documented but not the implementation itself. Verified locally with `deno doc --json` across all 14 entrypoints: 237 exported declarations, 0 now undocumented.

### @hertzg/crc — `percentageDocumentedSymbols` 0.50 → 1.0
Same root cause: `mod.ts` re-exports every symbol from `crc8.ts`/`crc16.ts`/`crc32.ts`/`crc64.ts` without its own doc comment. Added a one-line doc comment per re-exported specifier. Verified: 42 exported declarations, 0 undocumented.

### @hertzg/mymagti-api — `hasReadme`/`hasReadmeExamples`/`allEntrypointsDocs` false → true
`mod.ts` (the `.` entrypoint) had no module-level JSDoc at all, while `oauth/oauth.ts` (the `./oauth` entrypoint) already had one. Added a `@module` block to `mod.ts` with a runnable `@example` (mirroring the existing oauth example, imported from the package root) so JSR's jsdoc-derived README also gets example coverage. `percentageDocumentedSymbols` was already 1.0 and is untouched.

## Why `fix` and not `chore`

Per AGENTS.md, release-please uses commit type to determine version bump, and only `feat`/`fix`/`chore` are valid. A `chore` commit does not trigger a release, so the new docs would sit on `main` indefinitely without ever reaching jsr.io — the score would never move. Using `fix` forces release-please to cut a patch release for each package so the documentation actually ships.

## Test plan
- [x] `deno task lint` — passes
- [x] `deno task test` — passes (660 unit/integration tests, 521 doc-example tests, 0 failed)
- [x] `deno doc --json` coverage check for `@hertzg/ip` (14 entrypoints) and `@hertzg/crc` (5 entrypoints): 0 undocumented exported declarations in both
- [x] `deno doc --lint` clean for all touched files (pre-existing unrelated `private-type-ref` lint errors in `@hertzg/ip/4to6.ts` were not introduced by this change and are left untouched, out of scope)