### PR TITLE
chore(@binstruct/cli): record progressive discovery design as adrs

### DIFF
--- a/packages/@binstruct/cli/adr/0001-progressive-positional-disclosure.md
+++ b/packages/@binstruct/cli/adr/0001-progressive-positional-disclosure.md
@@ -1,0 +1,84 @@
+# ADR 0001 — Every argument prefix is a valid command that describes the next word
+
+**Status:** Accepted
+
+> Not yet implemented. The CLI currently requires all three values up front and
+> fails with `Error: Package specifier is required (-p,
+> --package)`. This ADR
+> records the target contract; ADRs 0002–0005 record the mechanisms it rests on.
+
+## Context
+
+The CLI takes three values before it can do anything: a package, a coder within
+that package, and a command. All three must be known in advance. Nothing in the
+tool tells you what any of them can be — `--help` shows `jsr:@binstruct/png` and
+`pngFile` as examples and stops there. To find a second coder you leave the
+terminal and read the JSR docs page.
+
+That is the wrong shape for a tool whose whole subject matter is a registry of
+30+ format packages, each exporting coders whose names you cannot guess
+(`arpData`, `ustarHeader`, `bitmapInfoHeader`).
+
+The obvious fix — an interactive picker with arrow keys — is worse. It breaks
+the pipeline usage that is the tool's entire point
+(`… decode < input.png > out.json`), it needs a TTY, and it cannot be pasted
+into a script or a README.
+
+## Decision
+
+The argument list is a **prefix chain**, and every prefix of it is a valid
+invocation:
+
+```
+binstruct [<package> [<coder> [<command>]]] [options]
+```
+
+When the next positional is missing, the CLI prints three blocks and stops:
+
+- **`NEXT`** — the name of the missing word and one line on what it means.
+- **an options block** — the legal values, discovered from what was already
+  typed (ADRs 0002 and 0003), each with its one-line doc.
+- **`TRY`** — a complete, paste-ready command line one step further along.
+
+The three levels are:
+
+| typed                   | missing     | options from           |
+| ----------------------- | ----------- | ---------------------- |
+| `binstruct`             | `<package>` | bundled registry       |
+| `binstruct png`         | `<coder>`   | `deno doc --json`      |
+| `binstruct png pngFile` | `<command>` | static: decode, encode |
+
+**An incomplete invocation is an error.** Guidance goes to **stderr** and the
+process exits **1**. `--help` prints the same material to **stdout** and exits
+**0**. There are no exceptions to this rule — not for the bare `binstruct`
+invocation, not for a TTY check.
+
+Discovery output never goes to stdout. Stdout carries the payload and nothing
+else.
+
+## Consequences
+
+- **A half-typed command cannot corrupt a redirect.** `binstruct png > out.json`
+  fails loudly and leaves `out.json` empty, instead of writing a help screen
+  into it.
+- **The tool teaches itself.** Each level ends with the next command, so a user
+  who knows only `binstruct` reaches a working decode in three keystroke rounds
+  without leaving the terminal.
+- **One renderer, three levels.** The blocks are identical in shape; only the
+  source of options differs. Adding a fourth level later costs a lookup
+  function, not a new UI.
+- **`--help` output and error output share a code path**, so they cannot drift.
+- **The flag form (`-p`, `-c`) is now the odd one out.** It keeps working, but
+  every example and error message teaches positionals. Whether it gets a
+  deprecation notice is deliberately left open.
+- **Exit 1 on bare `binstruct` will surprise someone.** It is the price of the
+  no-exceptions rule, and it is what makes the redirect guarantee above
+  unconditional.
+
+## References
+
+- `cli.ts` — `parseCliArgs`, `showHelp`, the current three required values
+- `@binstruct/cli` ADR 0002 — coder discovery via `deno doc --json`
+- `@binstruct/cli` ADR 0003 — the bundled package registry
+- `@binstruct/cli` ADR 0004 — bare names imply `jsr:` and `@binstruct`
+- `@binstruct/cli` ADR 0005 — a lone zero-arg coder is the default

--- a/packages/@binstruct/cli/adr/0002-coder-discovery-via-deno-doc.md
+++ b/packages/@binstruct/cli/adr/0002-coder-discovery-via-deno-doc.md
@@ -1,0 +1,88 @@
+# ADR 0002 — Coders are discovered by reading types with `deno doc --json`, not by importing the package
+
+**Status:** Accepted
+
+## Context
+
+ADR 0001 requires the CLI to list the coders a package exposes, with a one-line
+description for each, before the user has committed to running anything. Three
+mechanisms could produce that list.
+
+**Import the module and probe the exports.** Keep every export that is a
+zero-arity function, call it in a `try`, and test the result with `isCoder()`
+from `@hertzg/binstruct`. This works, and the CLI already imports the package to
+run a coder. But it executes third-party code merely because someone typed a
+package name to look around, and JavaScript does not retain JSDoc at runtime —
+so the descriptions, which are the entire point of a guidance UX, are lost.
+
+**Read the module graph with `deno info --json`.** Measured against
+`jsr:@binstruct/png`: it returns
+`{version, roots, modules,
+redirects, packages, npmPackages}` — 45 modules of
+dependency graph, **no export names and no types**. It answers "what does this
+package pull in", not "what does it expose". It cannot produce the list at all.
+
+**Read the types with `deno doc --json`.** Returns every exported symbol with
+its declaration kind, parameter list, return type and JSDoc, without evaluating
+anything.
+
+## Decision
+
+Coder discovery runs `deno doc --json --quiet <specifier>` and keeps every
+declaration where:
+
+- `kind === "function"`, and
+- `def.returnType.repr === "Coder"`.
+
+Each surviving entry yields a name, the decoded type
+(`def.returnType.value.typeParams[0].repr` — the `T` in `Coder<T>`), the first
+line of `jsDoc.doc`, and a count of required parameters. Entries are sorted with
+zero-required-parameter coders first.
+
+The resolved package version comes free from the same call: `location.filename`
+on any symbol is `https://jsr.io/@binstruct/png/0.4.0/mod.ts`. **`deno info` is
+not run on the happy path.** It is run only when discovery finds no coders,
+where its dependency graph distinguishes "this package does not depend on
+`@hertzg/binstruct`, it is probably not a binstruct package" from "it is one,
+but ships no type declarations".
+
+Formatted documentation is delegated rather than reimplemented. A `--docs` flag
+shells out to `deno doc --filter <symbol> <specifier>` for the coder and its
+decoded type. Two constraints found by measurement: the positional form
+`deno doc <spec> <Symbol>` that `deno doc --help` advertises **does not work**
+with a `jsr:` specifier — it resolves the symbol as a file path and errors — so
+`--filter` is mandatory; and `--filter` still prints the whole module doc as a
+preamble.
+
+## Consequences
+
+- **Exploration never executes third-party code.** Only a complete invocation
+  imports the package.
+- **Descriptions and decoded types are available**, so the listing can say
+  `pngFile → PngFile  Complete PNG files with automatic
+  chunk refinement.` and
+  `--docs` can show the exact object shape to write for `encode` — a question
+  the CLI could not previously answer at all.
+- **Cold discovery costs ~1.0–1.7s per package; warm is ~45ms.** Deno caches the
+  module graph, so the first lookup of the day pauses visibly with no spinner
+  and every later one is instant. Level 0 and complete invocations never pay it.
+- **Discovery needs `--allow-run=deno`.** The published usage already says `-A`,
+  but a tightened permission set breaks levels 1–2 while decode and encode keep
+  working. Discovery failure must therefore always print the "you can still name
+  the coder directly" escape hatch.
+- **Packages without type declarations show zero coders**, however well they
+  work at runtime. Untyped `npm:` packages are the likely case.
+- **The dependency age policy applies to discovery.** A package version
+  published inside the window of repo ADR 0011 makes `deno doc` fail outright,
+  with a message about minimum dependency age rather than anything the user did
+  wrong.
+- **Detection is a string match on `Coder`.** A coder returned through a type
+  alias that does not render as `Coder<…>` is invisible to discovery. This
+  constrains how format packages may declare their return types.
+
+## References
+
+- `loader.ts` — `loadCoder`, the runtime import path used to run
+- `@hertzg/binstruct` — `isCoder`, the rejected runtime-probe route
+- Repo ADR 0011 — dependency age policy
+- `@binstruct/cli` ADR 0001 — the disclosure contract this feeds

--- a/packages/@binstruct/cli/adr/0003-bundled-binstruct-only-registry.md
+++ b/packages/@binstruct/cli/adr/0003-bundled-binstruct-only-registry.md
@@ -1,0 +1,69 @@
+# ADR 0003 — The package list is a generated, `@binstruct`-only registry bundled in the CLI
+
+**Status:** Accepted
+
+## Context
+
+Level 0 of ADR 0001 — bare `binstruct` — must list the packages worth trying.
+Discovery by `deno doc` (ADR 0002) answers "what is in this package" but
+presupposes a package name, so it cannot produce this list.
+
+Three sources were available: query the JSR scope API at runtime, bundle a
+generated list, or hand-maintain a list. The JSR API is always current but adds
+a network round trip and a network permission to an otherwise offline command,
+and fails on a plane. Hand-maintenance drifts silently.
+
+A second question is scope. `@hertzg/*` also contains packages built on
+binstruct, and a bare name could in principle be resolved across both scopes.
+But `@hertzg` is a general-purpose utility scope — `mymagti-api`, `wg-keys`,
+`xhb`, `routeros-api` — that has nothing to do with binary format decoding.
+Mixing the two would present a list where most entries are irrelevant to the
+tool's subject.
+
+## Decision
+
+The CLI bundles a generated registry containing **package names only**,
+restricted to the `@binstruct` scope, excluding `@binstruct/cli` itself. An
+entry earns its place by exposing at least one coder under the ADR 0002 rule.
+
+The registry stores no descriptions. Every package name in this scope _is_ the
+format name — `png`, `tcp`, `wav`, `sqlite` — so prose adds nothing at the
+moment of choosing, while 30+ rows of it would fill the screen. Descriptions
+appear at level 1, once one package has been picked, taken from its module doc.
+
+A `_tools/check_cli_registry.ts` check, wired into `deno task lint`, regenerates
+the list and fails if it differs from the committed file.
+
+Packages outside `@binstruct` remain fully usable — `@hertzg/xhb`, `npm:…`,
+`https://…`, `./local` all work as specifiers (ADR 0004). They are simply not
+part of the discovery surface, and an unknown bare name gets an error that says
+so rather than a cross-scope search.
+
+## Consequences
+
+- **Level 0 is instant and offline.** No network, no subprocess, no new
+  permission.
+- **The list can go stale between releases.** A format package added after the
+  last CLI release is missing from the listing until the CLI ships again. It
+  stays usable throughout — the registry is a hint, not a gate.
+- **Staleness self-corrects.** The generated file lives under
+  `packages/@binstruct/cli/`, so adding a format package touches a path Release
+  Please attributes to the CLI, which cuts the release that carries the updated
+  list. This is the same mechanism that makes `_deps.snap` diffs releasable
+  under repo ADR 0005.
+- **Every new format package forces a CLI release.** Intended, and the cost of
+  the previous point.
+- **Names-only keeps the generator trivial** — a directory scan plus the ADR
+  0002 probe, with no description field to source, truncate or wrap.
+- **A `@binstruct` package that exposes no zero-argument coder still appears**
+  in the list and then dead-ends at level 1. `pcap` is this case today.
+
+## References
+
+- `_tools/check_readme.ts`, `_tools/check_labeler.ts` — the existing
+  generated-file-plus-lint-check pattern
+- Repo ADR 0005 — deps snapshot pinning, same release-attribution argument
+- Repo ADR 0009 — two-tier workspace layout, why the scopes are separate
+- `@binstruct/cli` ADR 0002 — the probe that decides membership
+- `@binstruct/cli` ADR 0004 — specifier resolution for everything outside the
+  registry

--- a/packages/@binstruct/cli/adr/0004-bare-names-imply-jsr-and-binstruct.md
+++ b/packages/@binstruct/cli/adr/0004-bare-names-imply-jsr-and-binstruct.md
@@ -1,0 +1,66 @@
+# ADR 0004 — A bare package name implies `jsr:` and the `@binstruct` scope
+
+**Status:** Accepted
+
+## Context
+
+The specifier is the first thing typed on every invocation, and in the
+overwhelming majority of cases it is one of thirty `@binstruct` packages.
+Spelling `jsr:@binstruct/png` in full makes the shortest useful command 34
+characters of boilerplate before anything interesting happens, and it appears in
+every example, every error message and every `TRY` line the CLI prints under
+ADR 0001.
+
+The specifier is forwarded to dynamic `import()` and to `deno doc`, both of
+which accept schemes, bare npm names, URLs and paths, so any shorthand has to be
+layered on without shadowing those forms.
+
+## Decision
+
+The specifier is resolved by first match:
+
+| input                                      | rule              | resolves to          |
+| ------------------------------------------ | ----------------- | -------------------- |
+| `jsr:@binstruct/png`, `npm:x`, `https://…` | has a scheme      | unchanged            |
+| `./x`, `../x`, `/abs/x`, `mod.ts`          | looks like a path | unchanged            |
+| `@hertzg/xhb`                              | starts with `@`   | `jsr:@hertzg/xhb`    |
+| `png`, `wav@0.2.0`                         | bare              | `jsr:@binstruct/png` |
+
+A scheme requires **at least two lowercase characters** before the colon
+(`^[a-z][a-z0-9+.-]+:`), so a bare name can never be mistaken for one. A path is
+anything beginning with `.` or `/`, or ending in a JS/TS extension.
+
+Version suffixes ride along: `wav@0.2.0` becomes `jsr:@binstruct/wav@0.2.0`,
+which `deno doc` resolves (verified against `jsr:@binstruct/png@0.3.2`).
+
+Bare-name resolution is **unconditional**. There is no lookup against the
+registry and no fallback to another scope: `binstruct
+xhb` resolves to
+`jsr:@binstruct/xhb`, fails to load, and the error says that bare names mean
+`@binstruct` and that other scopes need their full name.
+
+The CLI always echoes the resolved specifier as the first line of output, so the
+expansion is never invisible. Listings and `TRY` lines use the short form — the
+shorthand only helps if the tool teaches it.
+
+## Consequences
+
+- **The common command loses 20 characters**, and every generated `TRY` line
+  becomes short enough to read at a glance.
+- **Resolution is a pure function of the input string.** It does not consult the
+  registry, the network or the filesystem, so it cannot behave differently on a
+  stale registry or offline.
+- **A local directory named like a package is shadowed.** `png/` resolves to the
+  JSR package, not the directory; `./png` disambiguates. Documented in `--help`,
+  not defended against.
+- **Cross-scope discovery is deliberately absent.** `binstruct xhb` will not
+  find `@hertzg/xhb` for you, per ADR 0003.
+- **Scheme detection is a heuristic.** Two lowercase characters is enough for
+  every scheme that matters here while leaving single-letter Windows drive
+  prefixes out of scope.
+
+## References
+
+- `loader.ts` — `loadCoder`, which receives the resolved specifier
+- `@binstruct/cli` ADR 0003 — why the implied scope is `@binstruct`
+- `@binstruct/cli` ADR 0001 — where resolved and short forms are displayed

--- a/packages/@binstruct/cli/adr/0005-lone-coder-is-the-default.md
+++ b/packages/@binstruct/cli/adr/0005-lone-coder-is-the-default.md
@@ -1,0 +1,76 @@
+# ADR 0005 — When a package exposes exactly one zero-argument coder, the coder argument may be omitted
+
+**Status:** Accepted
+
+## Context
+
+ADR 0001 makes `<coder>` a required word between the package and the command.
+Running the discovery probe of ADR 0002 across every `@binstruct` package shows
+how often that word carries information. Zero-argument coders per package:
+
+| count | packages                                                                                                                                                                     |
+| ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1** | arp, au, bfd, dos-mz, esp, ethernet, icmp, icmpv6, ico, igmp, inet, ipv4, ipv6, mbr, mp3, ntp, pppoe, rtp, sll, sqlite, tar, tcp, tga, tls-record, udp, vlan, vxlan — **27** |
+| 3     | bmp, png                                                                                                                                                                     |
+| 6     | wav                                                                                                                                                                          |
+| **0** | pcap                                                                                                                                                                         |
+
+For 27 of 31 packages the word is pure ceremony: there is exactly one thing it
+could name, and the user must nonetheless look it up, because names like
+`arpData`, `ustarHeader` and `sllHeader` are not guessable from the package
+name.
+
+## Decision
+
+When discovery finds **exactly one** coder with no required parameters,
+`<coder>` may be omitted:
+
+```
+binstruct arp decode < arp.bin > arp.json
+```
+
+Consequences for the disclosure levels of ADR 0001: level 1 collapses into
+level 2. Bare `binstruct arp` names the single coder, notes that it may be
+omitted, and offers the commands directly, with a `TRY` line that skips the
+coder word.
+
+`decode` and `encode` are **reserved in the second positional**. If the second
+word matches a command name it is the command, and the coder is inferred. A
+coder actually named `decode` or `encode` is therefore unreachable by that
+shorthand; this is documented, not defended against.
+
+The inference is always announced on **stderr**:
+
+```
+using coder: arpData (only coder in jsr:@binstruct/arp)
+```
+
+The default applies only at exactly one candidate. Two or more — `png`, `bmp`,
+`wav` — always require the explicit name, with no notion of a privileged or
+"main" coder.
+
+## Consequences
+
+- **The ceremony disappears for 87% of packages**, including every network
+  protocol package, which is where the CLI gets most of its use.
+- **The shortcut is never silent.** The inferred name goes to stderr on every
+  run, so a script's log shows which coder actually ran and the redirect stays
+  clean.
+- **The set of commands is now load-bearing vocabulary.** Adding a third command
+  later shadows any coder sharing its name. Command names must stay few and
+  verb-shaped.
+- **Availability of the shortcut depends on a package's exports.** Adding a
+  second zero-argument coder to `@binstruct/arp` would break
+  `binstruct arp decode` for existing users — a breaking change in the CLI
+  caused by a feature addition elsewhere. Format packages need to know this.
+- **It rests on discovery.** Unlike specifier resolution (ADR 0004), the
+  shortcut cannot work when `deno doc` is unavailable, so the failure path must
+  fall back to demanding an explicit coder name.
+- **`pcap` is unreachable regardless.** Its only coder, `pcapFile(endianness)`,
+  takes a required argument, and the CLI has no way to supply one.
+
+## References
+
+- `@binstruct/cli` ADR 0001 — the positional contract being relaxed
+- `@binstruct/cli` ADR 0002 — the probe supplying the candidate set
+- `@binstruct/pcap` — `pcapFile(endianness)`, the zero-candidate case


### PR DESCRIPTION
Documentation only — five ADRs under `packages/@binstruct/cli/adr/`. No code changes, nothing implemented yet.

## Why

`@binstruct/cli` needs all three of package, coder and command up front, and tells you nothing about what any of them can be. `--help` shows `jsr:@binstruct/png` / `pngFile` as examples and stops. For a tool whose subject is a registry of 30+ format packages exporting names you cannot guess — `arpData`, `ustarHeader`, `bitmapInfoHeader` — that means leaving the terminal for the JSR docs page to get anything done.

These ADRs record a design for making the CLI guide you to the choice, without an interactive picker (which would break the pipeline usage that is the tool's whole point).

## Decisions

| # | Decision |
| --- | --- |
| 0001 | Every argument prefix is a valid command that describes the next word |
| 0002 | Coders discovered by reading types with `deno doc --json`, not by importing |
| 0003 | Generated, `@binstruct`-only package registry bundled in the CLI |
| 0004 | A bare package name implies `jsr:` and the `@binstruct` scope |
| 0005 | A lone zero-argument coder is the default |

The shape that falls out:

```
binstruct                      list packages
binstruct png                  list coders in @binstruct/png
binstruct png pngFile          list commands for that coder
binstruct png pngFile decode   run it
binstruct arp decode           coder omitted — arp has only one
```

Each level prints what the next word means, the legal values discovered from what was already typed, and a paste-ready command one step further along. Guidance goes to stderr and exits 1, so a half-typed command can never contaminate a redirect.

## Measurements behind them

Taken against the real registry, recorded in the ADRs:

- `deno doc --json` reports coder names, decoded types (`Coder<PngFile>`) and JSDoc without executing anything. Cold ~1.0–1.7s per package, warm ~45ms.
- `deno info --json` returns 45 modules of dependency graph for `@binstruct/png` and no export names at all, so it cannot produce the list. It is kept only for diagnosing the no-coders-found error.
- 27 of 31 packages expose exactly one zero-argument coder, which is what makes 0005 worth having.
- `@binstruct/pcap` exposes zero, because `pcapFile(endianness)` takes a required argument.

## Rejected, with reasons recorded

Interactive arrow-key picker; runtime `isCoder()` probing of imported exports; `deno info` as the discovery mechanism; cross-scope resolution of bare names into `@hertzg`.

## Deliberately left open

Whether `-p`/`-c` get a deprecation notice, and whether `--json` on an incomplete invocation should emit the discovery result machine-readably.

## Follow-up

#219 — argument-taking coders remain unreachable from the CLI, which keeps `@binstruct/pcap` unusable. Out of scope here; needs its own design.

One consequence worth flagging beyond the CLI: under 0005, adding a second zero-argument coder to a package like `@binstruct/arp` would break `binstruct arp decode` for existing users — a breaking CLI change caused by a feature addition in a different package.