### PR TITLE
feat(@binstruct/pcap): add zero-argument coder factories with endianness auto-detection

### DIFF
--- a/packages/@binstruct/pcap/adr/0001-zero-argument-endianness.md
+++ b/packages/@binstruct/pcap/adr/0001-zero-argument-endianness.md
@@ -1,0 +1,99 @@
+# ADR 0001 — Zero-argument coder factories: `pcapFile()` sniffs the magic, the building blocks default to little-endian
+
+**Status:** Accepted
+
+## Context
+
+Every coder factory this package exported required an `endianness` argument.
+That made `@binstruct/pcap` the only `@binstruct/*` package with no coder
+reachable as `factory()` — awkward for humans who just want to read a capture,
+and fatal for tooling that can only call a factory with no arguments (see issue
+#219, where `@binstruct/cli` cannot pass arguments at all and pcap is therefore
+unusable from it).
+
+Pcap is unusual among the formats in this scope: byte order is not fixed by the
+specification. Both little- and big-endian captures are valid, and the file
+announces which it is via the magic number at offset zero (`0xa1b2c3d4` read in
+the file's own order, `0xd4c3b2a1` byte-swapped). So on **decode** the correct
+answer is discoverable from the data. On **encode** there is nothing to inspect
+and a value must simply be chosen.
+
+The obvious composition — `struct({ magic, …rest })` where `rest` picks its
+coders based on the decoded `magic` — is not expressible. `ref`/`computedRef`
+resolve _values_ from earlier fields (binstruct ADR 0003), not _coders_;
+`refineSwitch` dispatches only after its base coder has already decoded the
+whole host (binstruct ADR 0005), which requires the base to be
+endianness-agnostic, which the pcap layout is not; `lazy`'s factory takes no
+context, so it cannot see decoded bytes. There is no "select the coder for the
+remaining fields from an earlier field's value" primitive.
+
+## Decision
+
+Three changes, all additive — passing an argument behaves exactly as before.
+
+**`pcapFile(endianness?)` resolves byte order per operation.** Given an argument
+it is the fixed-order coder it always was. Given none it returns a coder that,
+on decode, reads the magic with `detectPcapMagic` and delegates to a little- or
+big-endian `pcapFileWith` pair accordingly — header _and_ records switch
+together, so the file stays internally coherent. On encode it writes
+`PCAP_DEFAULT_ENDIANNESS`. A buffer with no recognised magic decodes as
+`PCAP_DEFAULT_ENDIANNESS` rather than throwing (repo ADR 0006).
+
+This coder is hand-written against the public `Coder` protocol rather than
+composed from primitives. Binstruct ADR 0001 sanctions exactly this — "the shape
+is the contract" — and it uses only exported API (`Coder`, `kCoderKind`,
+`createContext`, `refSetValue`). It reaches into nothing private.
+
+**`PCAP_DEFAULT_ENDIANNESS` is `"le"`, and is exported.** libpcap writes host
+order, and every mainstream capture host is little-endian. Naming the constant
+means the default is a documented part of the API that callers can assert
+against, not a literal buried in a signature.
+
+**`pcapGlobalHeader(endianness?)` and `pcapRecord(endianness?)` default to that
+constant and stay single-order.** A record carries no magic, so its byte order
+is recoverable only from the header that precedes it — a self-sniffing
+`pcapRecord()` is impossible. Making `pcapGlobalHeader()` sniff while
+`pcapRecord()` could not would let
+`pcapFileWith(pcapGlobalHeader(), pcapRecord())` decode a big-endian header and
+then little-endian records, silently. Auto-detection therefore lives only at the
+tier that owns the whole file.
+
+**`pcapFileWith(headerCoder, recordCoder)` keeps both arguments required.** It
+is the builder tier, exactly analogous to `@binstruct/png`'s
+`pngFileChunks(chunkCoder)`, and `png` ADR 0001 already settled that a builder
+may require arguments when a zero-argument sibling covers the common case.
+`pcapFile()` is that sibling.
+
+The optional parameters are spelled with a `?` and an internal
+`?? PCAP_DEFAULT_ENDIANNESS`, rather than as a parameter with a default value.
+The two are identical to a TypeScript caller, but `deno doc --json` reports a
+defaulted parameter as non-optional and a `?` parameter as optional — and
+reachability by `deno doc`-driven tooling is the whole point of the change.
+
+## Consequences
+
+- **Pcap is reachable from zero-argument tooling.** Three of four factories now
+  call bare, the same ratio as `png`.
+- **`pcapFile()` reads big-endian captures with no configuration**, which no
+  previous call could do without a `detectPcapMagic` probe first.
+- **Encode is asymmetric with decode.** `pcapFile()` round-trips any input, but
+  re-encoding a big-endian capture through the zero-argument coder emits
+  little-endian. Callers preserving on-disk byte order must pass the endianness
+  explicitly.
+- **One coder in this package is not pure composition.** It must be maintained
+  by hand if the `Coder` protocol changes.
+- **The gap is recorded, not worked around.** If binstruct ever grows a
+  primitive that selects a coder from an earlier decoded field, this coder
+  should be rewritten in terms of it.
+
+## References
+
+- `mod.ts` — `pcapFile`
+- `header.ts` — `PCAP_DEFAULT_ENDIANNESS`, `pcapGlobalHeader`, `detectPcapMagic`
+- `record.ts` — `pcapRecord`, `pcapFileWith`
+- `@binstruct/png` ADR 0001 — Two-tier coder API
+- `@hertzg/binstruct` ADR 0001 — Coder protocol
+- `@hertzg/binstruct` ADR 0003 — Refs resolve values, single-pass forward-only
+- `@hertzg/binstruct` ADR 0005 — `refineSwitch` dispatches on a host field
+- Repo ADR 0006 — No defensive programming
+- Issue #219 — `@binstruct/cli` cannot pass arguments to coder factories

--- a/packages/@binstruct/pcap/header.ts
+++ b/packages/@binstruct/pcap/header.ts
@@ -5,7 +5,8 @@
  * file and describes the byte order, version, and link-layer type of the
  * records that follow. The byte layout is fixed but two stored byte orders are
  * permitted; this module exposes a factory that takes the desired endianness
- * explicitly so callers stay in control of the wire layout.
+ * explicitly so callers stay in control of the wire layout, and defaults it to
+ * {@link PCAP_DEFAULT_ENDIANNESS} when omitted.
  */
 
 import { s32, struct, u16, u32 } from "@hertzg/binstruct";
@@ -19,6 +20,42 @@ import type { Coder } from "@hertzg/binstruct";
  * and every record header that follows it.
  */
 export type PcapEndianness = "le" | "be";
+
+/**
+ * Byte order assumed by the pcap coder factories when none is supplied.
+ *
+ * Little-endian is the byte order written by libpcap on every mainstream
+ * capture host (x86 and ARM alike), so it is what an arbitrary `.pcap` file is
+ * overwhelmingly likely to use. Decoding can do better than a guess — see
+ * {@link pcapFile}, which sniffs the magic — but encoding has no data to
+ * inspect, so it commits to this value.
+ *
+ * @example The default matches the explicit little-endian layout
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { PCAP_DEFAULT_ENDIANNESS, pcapGlobalHeader } from "@binstruct/pcap";
+ *
+ * assertEquals(PCAP_DEFAULT_ENDIANNESS, "le");
+ *
+ * const value = {
+ *   magic: 0xa1b2c3d4,
+ *   versionMajor: 2,
+ *   versionMinor: 4,
+ *   thisZone: 0,
+ *   sigFigs: 0,
+ *   snapLen: 65535,
+ *   network: 1,
+ * };
+ *
+ * const implicit = new Uint8Array(24);
+ * const explicit = new Uint8Array(24);
+ * pcapGlobalHeader().encode(value, implicit);
+ * pcapGlobalHeader(PCAP_DEFAULT_ENDIANNESS).encode(value, explicit);
+ *
+ * assertEquals(implicit, explicit);
+ * ```
+ */
+export const PCAP_DEFAULT_ENDIANNESS: PcapEndianness = "le";
 
 /**
  * Logical magic number for microsecond-resolution captures.
@@ -68,7 +105,11 @@ export interface PcapGlobalHeader {
  * Creates a coder for the pcap global header in the requested byte order.
  *
  * @param endianness Byte order used for the multi-byte fields. Pass `"le"` or
- *   `"be"` to match the file you are reading or producing.
+ *   `"be"` to match the file you are reading or producing. Defaults to
+ *   {@link PCAP_DEFAULT_ENDIANNESS}. This coder is fixed to one byte order —
+ *   to decode a header of unknown endianness, probe it with
+ *   {@link detectPcapMagic} first, or use {@link pcapFile}, which does that
+ *   for you.
  * @returns A coder that encodes/decodes a {@link PcapGlobalHeader}.
  *
  * @example Encode and decode a little-endian global header
@@ -124,18 +165,51 @@ export interface PcapGlobalHeader {
  * assertEquals(decoded.magic, PCAP_MAGIC_MICROS);
  * assertEquals(decoded.snapLen, 1500);
  * ```
+ *
+ * @example Omitting the argument round-trips using the default byte order
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import {
+ *   detectPcapMagic,
+ *   LINKTYPE,
+ *   PCAP_MAGIC_MICROS,
+ *   pcapGlobalHeader,
+ * } from "@binstruct/pcap";
+ *
+ * const header = pcapGlobalHeader();
+ * const value = {
+ *   magic: PCAP_MAGIC_MICROS,
+ *   versionMajor: 2,
+ *   versionMinor: 4,
+ *   thisZone: 0,
+ *   sigFigs: 0,
+ *   snapLen: 65535,
+ *   network: LINKTYPE.ETHERNET,
+ * };
+ *
+ * const buffer = new Uint8Array(24);
+ * const written = header.encode(value, buffer);
+ * const [decoded, read] = header.decode(buffer);
+ *
+ * assertEquals(written, 24);
+ * assertEquals(read, 24);
+ * assertEquals(decoded, value);
+ * assertEquals(detectPcapMagic(buffer), { endianness: "le", nanos: false });
+ * ```
  */
 export function pcapGlobalHeader(
-  endianness: PcapEndianness,
+  endianness?: PcapEndianness,
 ): Coder<PcapGlobalHeader> {
+  const order = endianness ?? PCAP_DEFAULT_ENDIANNESS;
+
   return struct({
-    magic: u32(endianness),
-    versionMajor: u16(endianness),
-    versionMinor: u16(endianness),
-    thisZone: s32(endianness),
-    sigFigs: u32(endianness),
-    snapLen: u32(endianness),
-    network: u32(endianness),
+    magic: u32(order),
+    versionMajor: u16(order),
+    versionMinor: u16(order),
+    thisZone: s32(order),
+    sigFigs: u32(order),
+    snapLen: u32(order),
+    network: u32(order),
   });
 }
 

--- a/packages/@binstruct/pcap/mod.test.ts
+++ b/packages/@binstruct/pcap/mod.test.ts
@@ -2,6 +2,7 @@ import { assertEquals, assertThrows } from "@std/assert";
 import {
   detectPcapMagic,
   LINKTYPE,
+  PCAP_DEFAULT_ENDIANNESS,
   PCAP_MAGIC_MICROS,
   PCAP_MAGIC_NANOS,
   pcapFile,
@@ -11,6 +12,7 @@ import {
 } from "./mod.ts";
 import type { PcapGlobalHeader, PcapRecord } from "./mod.ts";
 import { refine } from "@hertzg/binstruct/refine";
+import { createContext } from "@hertzg/binstruct";
 
 const GLOBAL_HEADER_SIZE = 24;
 const RECORD_HEADER_SIZE = 16;
@@ -340,4 +342,140 @@ Deno.test("real-world fixture: Wireshark dns.cap", async () => {
     assertEquals(record.inclLen, record.origLen);
     assertEquals(record.data.byteLength, record.inclLen);
   }
+});
+
+Deno.test("PCAP_DEFAULT_ENDIANNESS: is little-endian", () => {
+  assertEquals(PCAP_DEFAULT_ENDIANNESS, "le");
+});
+
+Deno.test("pcapGlobalHeader: omitted endianness matches the default", () => {
+  const value = sampleHeader();
+
+  const implicit = new Uint8Array(GLOBAL_HEADER_SIZE);
+  const explicit = new Uint8Array(GLOBAL_HEADER_SIZE);
+  const written = pcapGlobalHeader().encode(value, implicit);
+  pcapGlobalHeader(PCAP_DEFAULT_ENDIANNESS).encode(value, explicit);
+
+  const [decoded, read] = pcapGlobalHeader().decode(implicit);
+
+  assertEquals(implicit, explicit);
+  assertEquals(written, GLOBAL_HEADER_SIZE);
+  assertEquals(read, GLOBAL_HEADER_SIZE);
+  assertEquals(decoded, value);
+});
+
+Deno.test("pcapRecord: omitted endianness matches the default", () => {
+  const value = sampleRecord(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
+
+  const implicit = new Uint8Array(64);
+  const explicit = new Uint8Array(64);
+  const written = pcapRecord().encode(value, implicit);
+  pcapRecord(PCAP_DEFAULT_ENDIANNESS).encode(value, explicit);
+
+  const [decoded, read] = pcapRecord().decode(implicit);
+
+  assertEquals(implicit, explicit);
+  assertEquals(written, RECORD_HEADER_SIZE + 4);
+  assertEquals(read, RECORD_HEADER_SIZE + 4);
+  assertEquals(decoded, value);
+});
+
+Deno.test("pcapFile: zero-argument encode uses the default endianness", () => {
+  const value = {
+    header: sampleHeader(),
+    records: [sampleRecord(new Uint8Array([0x01, 0x02, 0x03]))],
+  };
+
+  const implicit = new Uint8Array(128);
+  const explicit = new Uint8Array(128);
+  const written = pcapFile().encode(value, implicit);
+  const expected = pcapFile(PCAP_DEFAULT_ENDIANNESS).encode(value, explicit);
+
+  assertEquals(written, expected);
+  assertEquals(implicit, explicit);
+  assertEquals(detectPcapMagic(implicit), {
+    endianness: PCAP_DEFAULT_ENDIANNESS,
+    nanos: false,
+  });
+});
+
+Deno.test("pcapFile: zero-argument decode detects endianness from the magic", () => {
+  const value = {
+    header: sampleHeader(),
+    records: [
+      sampleRecord(new Uint8Array([0xde, 0xad, 0xbe, 0xef])),
+      sampleRecord(new Uint8Array([0x11, 0x22]), 1500),
+    ],
+  };
+
+  const auto = pcapFile();
+
+  for (const endianness of ["le", "be"] as const) {
+    const buffer = new Uint8Array(128);
+    const written = pcapFile(endianness).encode(value, buffer);
+    const encoded = buffer.subarray(0, written);
+
+    assertEquals(detectPcapMagic(encoded)?.endianness, endianness);
+
+    const [decoded, read] = auto.decode(encoded);
+
+    assertEquals(read, written);
+    assertEquals(decoded, value);
+  }
+});
+
+Deno.test("pcapFile: zero-argument decode reads a nanosecond big-endian capture", () => {
+  const value = {
+    header: { ...sampleHeader(), magic: PCAP_MAGIC_NANOS },
+    records: [sampleRecord(new Uint8Array([0xff]))],
+  };
+
+  const buffer = new Uint8Array(128);
+  const written = pcapFile("be").encode(value, buffer);
+
+  const [decoded] = pcapFile().decode(buffer.subarray(0, written));
+
+  assertEquals(decoded, value);
+  assertEquals(detectPcapMagic(buffer), { endianness: "be", nanos: true });
+});
+
+Deno.test("pcapFile: zero-argument decode falls back to the default on unknown magic", () => {
+  const value = { header: { ...sampleHeader(), magic: 0 }, records: [] };
+
+  const buffer = new Uint8Array(GLOBAL_HEADER_SIZE);
+  const written = pcapFile(PCAP_DEFAULT_ENDIANNESS).encode(value, buffer);
+
+  assertEquals(detectPcapMagic(buffer), null);
+
+  const [decoded] = pcapFile().decode(buffer.subarray(0, written));
+
+  assertEquals(decoded, value);
+});
+
+Deno.test("pcapFile: zero-argument coder reads the dns.cap fixture", async () => {
+  const fixture = await Deno.readFile(
+    new URL("./_fixtures/dns.cap", import.meta.url),
+  );
+
+  const [auto, autoRead] = pcapFile().decode(fixture);
+  const [explicit, explicitRead] = pcapFile("le").decode(fixture);
+
+  assertEquals(autoRead, explicitRead);
+  assertEquals(auto, explicit);
+  assertEquals(auto.records.length, 38);
+});
+
+Deno.test("pcapFile: zero-argument coder is usable as a struct field", () => {
+  const value = { header: sampleHeader(), records: [] };
+
+  const buffer = new Uint8Array(GLOBAL_HEADER_SIZE);
+  const written = pcapFile().encode(value, buffer, createContext("encode"));
+  const [decoded, read] = pcapFile().decode(
+    buffer.subarray(0, written),
+    createContext("decode"),
+  );
+
+  assertEquals(written, GLOBAL_HEADER_SIZE);
+  assertEquals(read, GLOBAL_HEADER_SIZE);
+  assertEquals(decoded, value);
 });

--- a/packages/@binstruct/pcap/mod.ts
+++ b/packages/@binstruct/pcap/mod.ts
@@ -13,9 +13,16 @@
  * ## Endianness
  *
  * Pcap stores numbers in either little- or big-endian, signalled by the magic
- * value at offset zero. Callers pick the byte order explicitly via the
- * `endianness` argument (`"le"` or `"be"`); use {@link detectPcapMagic} to
- * probe an unknown buffer first when needed.
+ * value at offset zero. Callers may pick the byte order explicitly via the
+ * `endianness` argument (`"le"` or `"be"`).
+ *
+ * Omitting it is the easy path: {@link pcapFile} then reads that magic and
+ * decodes the whole capture in whichever order the file itself declares, so a
+ * single `pcapFile()` handles little- and big-endian captures alike. Encoding
+ * has no file to inspect and writes {@link PCAP_DEFAULT_ENDIANNESS}. The
+ * building blocks {@link pcapGlobalHeader} and {@link pcapRecord} are fixed to
+ * one byte order and default to that same constant — {@link detectPcapMagic}
+ * probes a buffer when you drive them yourself.
  *
  * ## Timestamp resolution
  *
@@ -260,8 +267,15 @@
  * @module @binstruct/pcap
  */
 
-import type { Coder } from "@hertzg/binstruct";
 import {
+  type Coder,
+  createContext,
+  kCoderKind,
+  refSetValue,
+} from "@hertzg/binstruct";
+import {
+  detectPcapMagic,
+  PCAP_DEFAULT_ENDIANNESS,
   type PcapEndianness,
   type PcapGlobalHeader,
   pcapGlobalHeader,
@@ -275,6 +289,7 @@ import {
 
 export {
   detectPcapMagic,
+  PCAP_DEFAULT_ENDIANNESS,
   PCAP_MAGIC_MICROS,
   PCAP_MAGIC_NANOS,
   pcapGlobalHeader,
@@ -289,8 +304,14 @@ export type { PcapFile, PcapRecord } from "./record.ts";
 export { LINKTYPE } from "./linktypes.ts";
 export type { LinkType } from "./linktypes.ts";
 
+/** Decoded shape produced by the standard {@link pcapFile} coder. */
+type PcapFileValue = PcapFile<PcapGlobalHeader, PcapRecord>;
+
+/** Distinguishes the endianness-sniffing file coder from a plain struct coder. */
+const kKindPcapFileAuto = Symbol("pcapFileAuto");
+
 /**
- * Creates a coder for a complete pcap capture file in the requested byte order.
+ * Creates a coder for a complete pcap capture file.
  *
  * The returned coder pairs {@link pcapGlobalHeader} with {@link pcapRecord} via
  * {@link pcapFileWith}. Records are read greedily until the buffer no longer
@@ -298,7 +319,26 @@ export type { LinkType } from "./linktypes.ts";
  * example, refining the payload into a parsed link-layer frame — use
  * {@link pcapFileWith} directly with your own coders.
  *
- * @param endianness Byte order matching the file's magic.
+ * ## Byte order
+ *
+ * Called **with** an endianness, the coder is fixed to that byte order for both
+ * directions — identical to every earlier release.
+ *
+ * Called **without** one, the coder resolves the byte order per operation:
+ *
+ * - On **decode** it reads the file's own magic number via
+ *   {@link detectPcapMagic} and decodes the header *and* every record in the
+ *   byte order that magic implies. Little- and big-endian captures therefore
+ *   both round-trip through the same coder, with no configuration. A buffer
+ *   whose first four bytes are not a recognised pcap magic is decoded as
+ *   {@link PCAP_DEFAULT_ENDIANNESS}.
+ * - On **encode** there is no file to inspect, so the coder writes
+ *   {@link PCAP_DEFAULT_ENDIANNESS}. Note that the `magic` field is a logical
+ *   value: writing {@link PCAP_MAGIC_MICROS} produces the correct on-disk byte
+ *   sequence for whichever order is in effect.
+ *
+ * @param endianness Byte order matching the file's magic. Omit it to sniff the
+ *   magic on decode and use {@link PCAP_DEFAULT_ENDIANNESS} on encode.
  * @returns A coder for a {@link PcapFile} of {@link PcapGlobalHeader} and
  *   {@link PcapRecord}.
  *
@@ -328,9 +368,121 @@ export type { LinkType } from "./linktypes.ts";
  *
  * assertEquals(written, 24);
  * ```
+ *
+ * @example One zero-argument coder reads captures of either byte order
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import {
+ *   LINKTYPE,
+ *   PCAP_MAGIC_MICROS,
+ *   pcapFile,
+ * } from "@binstruct/pcap";
+ *
+ * const capture = {
+ *   header: {
+ *     magic: PCAP_MAGIC_MICROS,
+ *     versionMajor: 2,
+ *     versionMinor: 4,
+ *     thisZone: 0,
+ *     sigFigs: 0,
+ *     snapLen: 65535,
+ *     network: LINKTYPE.ETHERNET,
+ *   },
+ *   records: [{
+ *     tsSec: 1_700_000_000,
+ *     tsUsec: 250_000,
+ *     inclLen: 4,
+ *     origLen: 1500,
+ *     data: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+ *   }],
+ * };
+ *
+ * const little = new Uint8Array(64);
+ * const big = new Uint8Array(64);
+ * const leWritten = pcapFile("le").encode(capture, little);
+ * const beWritten = pcapFile("be").encode(capture, big);
+ *
+ * const auto = pcapFile();
+ * const [fromLe] = auto.decode(little.subarray(0, leWritten));
+ * const [fromBe] = auto.decode(big.subarray(0, beWritten));
+ *
+ * assertEquals(fromLe, capture);
+ * assertEquals(fromBe, capture);
+ * ```
+ *
+ * @example Zero-argument round trip writes the default byte order
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import {
+ *   detectPcapMagic,
+ *   LINKTYPE,
+ *   PCAP_DEFAULT_ENDIANNESS,
+ *   PCAP_MAGIC_NANOS,
+ *   pcapFile,
+ * } from "@binstruct/pcap";
+ *
+ * const coder = pcapFile();
+ * const capture = {
+ *   header: {
+ *     magic: PCAP_MAGIC_NANOS,
+ *     versionMajor: 2,
+ *     versionMinor: 4,
+ *     thisZone: 0,
+ *     sigFigs: 0,
+ *     snapLen: 1500,
+ *     network: LINKTYPE.RAW,
+ *   },
+ *   records: [],
+ * };
+ *
+ * const buffer = new Uint8Array(24);
+ * const written = coder.encode(capture, buffer);
+ * const [decoded, read] = coder.decode(buffer.subarray(0, written));
+ *
+ * assertEquals(written, 24);
+ * assertEquals(read, 24);
+ * assertEquals(decoded, capture);
+ * assertEquals(detectPcapMagic(buffer), {
+ *   endianness: PCAP_DEFAULT_ENDIANNESS,
+ *   nanos: true,
+ * });
+ * ```
  */
 export function pcapFile(
-  endianness: PcapEndianness,
+  endianness?: PcapEndianness,
 ): Coder<PcapFile<PcapGlobalHeader, PcapRecord>> {
-  return pcapFileWith(pcapGlobalHeader(endianness), pcapRecord(endianness));
+  const fixed = (order: PcapEndianness) =>
+    pcapFileWith(pcapGlobalHeader(order), pcapRecord(order));
+
+  if (endianness !== undefined) {
+    return fixed(endianness);
+  }
+
+  const byOrder: Record<PcapEndianness, Coder<PcapFileValue>> = {
+    le: fixed("le"),
+    be: fixed("be"),
+  };
+
+  let self: Coder<PcapFileValue>;
+  return self = {
+    [kCoderKind]: kKindPcapFileAuto,
+    encode: (decoded, target, context) => {
+      const ctx = context ?? createContext("encode");
+      const bytesWritten = byOrder[PCAP_DEFAULT_ENDIANNESS].encode(
+        decoded,
+        target,
+        ctx,
+      );
+      refSetValue(ctx, self, decoded);
+      return bytesWritten;
+    },
+    decode: (encoded, context) => {
+      const ctx = context ?? createContext("decode");
+      const order = detectPcapMagic(encoded)?.endianness ??
+        PCAP_DEFAULT_ENDIANNESS;
+      const [decoded, bytesRead] = byOrder[order].decode(encoded, ctx);
+      refSetValue(ctx, self, decoded);
+      return [decoded, bytesRead];
+    },
+  };
 }

--- a/packages/@binstruct/pcap/record.ts
+++ b/packages/@binstruct/pcap/record.ts
@@ -9,7 +9,7 @@
 
 import { arrayWhile, bytes, ref, struct, u32 } from "@hertzg/binstruct";
 import type { Coder } from "@hertzg/binstruct";
-import type { PcapEndianness } from "./header.ts";
+import { PCAP_DEFAULT_ENDIANNESS, type PcapEndianness } from "./header.ts";
 
 /**
  * Decoded representation of a single pcap record.
@@ -44,7 +44,14 @@ export interface PcapRecord {
  * The payload length is taken from the `inclLen` field via a forward
  * reference, so records of any captured size round-trip correctly.
  *
- * @param endianness Byte order matching the surrounding pcap file.
+ * A record carries no magic of its own, so its byte order cannot be recovered
+ * from the record bytes — it is dictated entirely by the global header that
+ * precedes it. When the argument is omitted the coder assumes
+ * {@link PCAP_DEFAULT_ENDIANNESS}; pass the endianness explicitly whenever the
+ * surrounding file might be big-endian.
+ *
+ * @param endianness Byte order matching the surrounding pcap file. Defaults to
+ *   {@link PCAP_DEFAULT_ENDIANNESS}.
  * @returns A coder that encodes/decodes a {@link PcapRecord}.
  *
  * @example Round-trip a single record
@@ -94,18 +101,48 @@ export interface PcapRecord {
  * assertEquals(decoded.origLen, 1500);
  * assertEquals(decoded.data.length, 2);
  * ```
+ *
+ * @example Omitting the argument round-trips using the default byte order
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { PCAP_DEFAULT_ENDIANNESS, pcapRecord } from "@binstruct/pcap";
+ *
+ * const value = {
+ *   tsSec: 1_700_000_000,
+ *   tsUsec: 123_456,
+ *   inclLen: 3,
+ *   origLen: 3,
+ *   data: new Uint8Array([0x01, 0x02, 0x03]),
+ * };
+ *
+ * const implicit = new Uint8Array(32);
+ * const explicit = new Uint8Array(32);
+ * const written = pcapRecord().encode(value, implicit);
+ * pcapRecord(PCAP_DEFAULT_ENDIANNESS).encode(value, explicit);
+ *
+ * const [decoded, read] = pcapRecord().decode(implicit);
+ *
+ * assertEquals(implicit, explicit);
+ * assertEquals(written, 19);
+ * assertEquals(read, 19);
+ * assertEquals(decoded, value);
+ * ```
  */
-export function pcapRecord(endianness: PcapEndianness): Coder<PcapRecord> {
+export function pcapRecord(
+  endianness?: PcapEndianness,
+): Coder<PcapRecord> {
+  const order = endianness ?? PCAP_DEFAULT_ENDIANNESS;
+
   // inclLen is bound to a const so the bytes() coder can ref() the same
-  // identity we register in the struct — sibling fields call u32(endianness)
+  // identity we register in the struct — sibling fields call u32(order)
   // inline because their values aren't referenced elsewhere.
-  const inclLen = u32(endianness);
+  const inclLen = u32(order);
 
   return struct({
-    tsSec: u32(endianness),
-    tsUsec: u32(endianness),
+    tsSec: u32(order),
+    tsUsec: u32(order),
     inclLen,
-    origLen: u32(endianness),
+    origLen: u32(order),
     data: bytes(ref(inclLen)),
   });
 }
@@ -132,6 +169,13 @@ export interface PcapFile<THeader, TRecord> {
  * Records are decoded greedily until fewer than 16 bytes (the record-header
  * size) remain in the buffer; this matches how typical pcap readers consume a
  * file to its end without needing an explicit count.
+ *
+ * This is the builder tier of the package's coder API: it deliberately keeps
+ * both coders required, because there is no single obvious pair to default to
+ * once the caller has opted into custom header or record handling. Callers who
+ * just want to read or write an ordinary capture use {@link pcapFile}, the
+ * zero-argument sibling that supplies the standard pair and picks the byte
+ * order for you.
  *
  * @template THeader Decoded shape produced by the header coder.
  * @template TRecord Decoded shape produced by the record coder.


### PR DESCRIPTION
## Goal

Every exported coder factory in the `@binstruct/*` packages should be callable with **no arguments**, so a caller who wants the ordinary behaviour gets it without supplying configuration — and so tooling that can only call `factory()` can reach it.

Purely additive. Every existing call site that passes arguments compiles and behaves identically.

## Audit

I re-ran the `deno doc --json` probe over all 32 `@binstruct/*` packages (counting exported functions returning `Coder<...>` with zero required parameters), and had a second pass review the factories semantically rather than just numerically. Only `cli` was excluded (it is being rewritten on another branch).

The result confirms the expected picture:

| Package | Zero-arg factories before | Notes |
|---|---|---|
| `pcap` | **0 of 4** | the only package with none — the subject of this PR |
| `png` | 3 of 4 | `pngFileChunks(chunkCoder)` requires an argument, but `pngFile()` is its zero-arg sibling |
| `wav` | 6 of 6 | |
| `bmp` | 3 of 3 | |
| `inet` | 2 of 2 | |
| the other 26 | 1 of 1 each | |

Two things the raw count did not show, both checked:

- **No package outside `pcap` has a factory with an optional or defaulted parameter at all.** They are either zero-arg or (in png's single case) genuinely required. So there was no defaulted-parameter footgun to correct anywhere else.
- **`pngFileChunks(chunkCoder)` is the only remaining required-argument coder factory in the whole set**, and it is deliberate: `@binstruct/png` ADR 0001 defines the two-tier API precisely so a builder may require arguments when a zero-argument sibling covers the common case. Left alone.

Sub-entrypoints were checked too: only `cli` has any (`./cli`), so `mod.ts` is the complete public surface for every package in scope.

**Net: `pcap` is the only package that needed changing.**

## What changed — `@binstruct/pcap`

Pcap is the odd one out because byte order is not fixed by the format. Both little- and big-endian captures are valid, and the file announces which it is via the magic at offset zero.

**`pcapFile(endianness?)` — resolves byte order per operation.**

With an argument it is unchanged. Without one, it returns a coder that on **decode** reads the file's own magic via `detectPcapMagic` and decodes the header *and every record* in the order that magic implies, so little- and big-endian captures both round-trip through a single `pcapFile()`. On **encode** there is no file to inspect, so it writes the documented default. A buffer with no recognised magic decodes as the default rather than throwing (repo ADR 0006).

**`PCAP_DEFAULT_ENDIANNESS` — new export, `"le"`.** libpcap writes host order and every mainstream capture host is little-endian. Naming it makes the default an assertable part of the API rather than a literal buried in a signature.

**`pcapGlobalHeader(endianness?)` and `pcapRecord(endianness?)` — optional, defaulting to that constant, still single-order.**

Deliberately *not* self-sniffing. A record carries no magic, so its byte order is recoverable only from the header before it — a self-detecting `pcapRecord()` is impossible. Had `pcapGlobalHeader()` sniffed while `pcapRecord()` could not, `pcapFileWith(pcapGlobalHeader(), pcapRecord())` would silently decode a big-endian header followed by little-endian records. Auto-detection belongs only at the tier that owns the whole file.

**`pcapFileWith(headerCoder, recordCoder)` — left alone.** It is the builder tier, directly analogous to `pngFileChunks`, with `pcapFile()` as its zero-arg sibling. Same 3-of-4 shape as `png`.

Recorded as `packages/@binstruct/pcap/adr/0001-zero-argument-endianness.md`.

## Two findings worth flagging

**1. Optional parameters are spelled `?`, not `= default`.** `deno doc --json` reports a parameter with a default value as **non-optional**, and only an `?` parameter as optional. Since reachability from `deno doc`-driven tooling is the entire point, `endianness?: PcapEndianness` with an internal `?? PCAP_DEFAULT_ENDIANNESS` is the spelling that actually works. Identical to a TypeScript caller; not identical to the probe. Worth knowing for the CLI work.

**2. A missing binstruct primitive.** The natural composition — `struct({ magic, ...rest })` where `rest` selects its coders from the decoded `magic` — is **not expressible today**, and I did not hack around it:

- `ref` / `computedRef` resolve *values* from earlier fields, not *coders* (binstruct ADR 0003).
- `refineSwitch` dispatches only after its base coder has decoded the whole host (binstruct ADR 0005), which needs an endianness-agnostic base — the pcap layout is not.
- `lazy`'s factory takes no context, so it cannot see decoded bytes.

So `pcapFile()`'s auto-detecting form is a small hand-written coder against the **public** `Coder` protocol, using only exported API (`Coder`, `kCoderKind`, `createContext`, `refSetValue`). Binstruct ADR 0001 sanctions this explicitly — "the shape is the contract". Nothing private is touched. If binstruct ever grows a "select the coder for later fields from an earlier field's value" primitive, this coder should be rewritten in terms of it; the ADR says so.

## Deliberately out of scope

The semantic review turned up several **pre-existing** correctness issues unrelated to zero-argument reachability. Fixing any of them would be a breaking change and does not belong in this PR — flagging them for separate issues:

- **`wav`** (most serious): `dataChunk()` and `listChunk()` use `array(u8le(), u32le())`, which is *length-prefixed*, emitting a redundant 4-byte size after `chunkSize`. `wavFile()` therefore cannot read or write a real `.wav`; all tests are self-round-trips with no real fixture. `fmtChunk()` also always codes `cbSize`, making a canonical 16-byte PCM `fmt ` chunk impossible, and `wavFile()`'s JSDoc claims fact/LIST/reordering support the implementation does not have.
- **`png`**: `pngFile()` does not terminate on `IEND`; it consumes chunks while ≥12 bytes remain, decoding trailing padding as phantom chunks (visible but uncommented in its own module example).
- **`bmp`**: decoded `pixelOffset` is ignored; files with palettes or BI_BITFIELDS masks decode misaligned.
- **`tar`**: GNU base-256 numeric fields decode to `NaN`.
- **`arp`**: declared address lengths are decoded then ignored (disclosed in JSDoc, but the exported type constants invite the wrong assumption).

## Verification

- `deno task lint` — exit 0
- `deno task test` — exit 0 (46 pcap tests including doc examples; new tests cover both-endianness auto-detect, unknown-magic fallback, the real `dns.cap` fixture, and encode→decode round-trip integrity)
- `deno fmt` run only on changed paths
- Post-change probe: `pcapFile(endianness?)`, `pcapGlobalHeader(endianness?)`, `pcapRecord(endianness?)` all `req=0`

## Related

Reduces #219 from the other end — a zero-argument `pcapFile()` makes pcap reachable without the CLI needing argument support. **Does not close it**: the general inability to pass arguments to coder factories remains, and `pngFileChunks` is still unreachable from the CLI.