### PR TITLE
fix(@binstruct/wav)!: drive chunk payload length from chunkSize

### DIFF
--- a/packages/@binstruct/wav/mod.test.ts
+++ b/packages/@binstruct/wav/mod.test.ts
@@ -38,13 +38,13 @@ Deno.test("WAV package - basic PCM encoding/decoding", () => {
   const bytesWritten = wavCoder.encode(testWav, buffer);
   const [decoded, _bytesRead] = wavCoder.decode(buffer);
 
-  assertEquals(bytesWritten, 1050); // 12 (RIFF) + 24 (fmt) + 1012 (data with length prefix)
+  assertEquals(bytesWritten, 1046); // 12 (RIFF) + 26 (fmt) + 1008 (data)
   assertEquals(decoded.riff.chunkId, "RIFF");
   assertEquals(decoded.riff.format, "WAVE");
   assertEquals(decoded.fmt.audioFormat, 1);
   assertEquals(decoded.fmt.numChannels, 1);
   assertEquals(decoded.fmt.sampleRate, 44100);
-  assertEquals(decoded.data.audioData.length, 1000); // Length-prefixed array matches original length
+  assertEquals(decoded.data.audioData.length, 1000); // Exactly chunkSize bytes
 });
 
 Deno.test("WAV package - IEEE float format", () => {
@@ -77,11 +77,11 @@ Deno.test("WAV package - IEEE float format", () => {
   const bytesWritten = wavCoder.encode(floatWav, buffer);
   const [decoded, _bytesRead] = wavCoder.decode(buffer);
 
-  assertEquals(bytesWritten, 850); // 12 (RIFF) + 24 (fmt) + 812 (data with length prefix)
+  assertEquals(bytesWritten, 846); // 12 (RIFF) + 26 (fmt) + 808 (data)
   assertEquals(decoded.fmt.audioFormat, 3);
   assertEquals(decoded.fmt.numChannels, 2);
   assertEquals(decoded.fmt.sampleRate, 48000);
-  assertEquals(decoded.data.audioData.length, 800); // Length-prefixed array matches original length
+  assertEquals(decoded.data.audioData.length, 800); // Exactly chunkSize bytes
 });
 
 Deno.test("WAV package - multiple channel configurations", async (t) => {
@@ -115,7 +115,7 @@ Deno.test("WAV package - multiple channel configurations", async (t) => {
     const bytesWritten = wavCoder.encode(monoWav, buffer);
     const [decoded, _bytesRead] = wavCoder.decode(buffer);
 
-    assertEquals(bytesWritten, 1050); // 12 (RIFF) + 24 (fmt) + 1012 (data with length prefix)
+    assertEquals(bytesWritten, 1046); // 12 (RIFF) + 26 (fmt) + 1008 (data)
     assertEquals(decoded.fmt.numChannels, 1);
     assertEquals(decoded.fmt.bitsPerSample, 8);
   });
@@ -150,7 +150,7 @@ Deno.test("WAV package - multiple channel configurations", async (t) => {
     const bytesWritten = wavCoder.encode(stereoWav, buffer);
     const [decoded, _bytesRead] = wavCoder.decode(buffer);
 
-    assertEquals(bytesWritten, 2050); // 12 (RIFF) + 24 (fmt) + 2014 (data with length prefix)
+    assertEquals(bytesWritten, 2046); // 12 (RIFF) + 26 (fmt) + 2008 (data)
     assertEquals(decoded.fmt.numChannels, 2);
     assertEquals(decoded.fmt.bitsPerSample, 16);
   });
@@ -187,7 +187,7 @@ Deno.test("WAV package - different sample rates", async (t) => {
     const bytesWritten = wavCoder.encode(wav8k, buffer);
     const [decoded, _bytesRead] = wavCoder.decode(buffer);
 
-    assertEquals(bytesWritten, 1050); // 12 (RIFF) + 24 (fmt) + 1012 (data with length prefix)
+    assertEquals(bytesWritten, 1046); // 12 (RIFF) + 26 (fmt) + 1008 (data)
     assertEquals(decoded.fmt.sampleRate, 8000);
   });
 
@@ -221,7 +221,7 @@ Deno.test("WAV package - different sample rates", async (t) => {
     const bytesWritten = wavCoder.encode(wav44k, buffer);
     const [decoded, _bytesRead] = wavCoder.decode(buffer);
 
-    assertEquals(bytesWritten, 1050); // 12 (RIFF) + 24 (fmt) + 1012 (data with length prefix)
+    assertEquals(bytesWritten, 1046); // 12 (RIFF) + 26 (fmt) + 1008 (data)
     assertEquals(decoded.fmt.sampleRate, 44100);
   });
 
@@ -255,7 +255,7 @@ Deno.test("WAV package - different sample rates", async (t) => {
     const bytesWritten = wavCoder.encode(wav48k, buffer);
     const [decoded, _bytesRead] = wavCoder.decode(buffer);
 
-    assertEquals(bytesWritten, 1050); // 12 (RIFF) + 24 (fmt) + 1012 (data with length prefix)
+    assertEquals(bytesWritten, 1046); // 12 (RIFF) + 26 (fmt) + 1008 (data)
     assertEquals(decoded.fmt.sampleRate, 48000);
   });
 });
@@ -297,7 +297,7 @@ Deno.test("WAV package - round-trip integrity", () => {
   const bytesWritten = wavCoder.encode(originalWav, buffer);
   const [decoded, _bytesRead] = wavCoder.decode(buffer);
 
-  assertEquals(bytesWritten, 1050); // 12 (RIFF) + 24 (fmt) + 1012 (data with length prefix)
+  assertEquals(bytesWritten, 1046); // 12 (RIFF) + 26 (fmt) + 1008 (data)
   assertEquals(decoded.riff.chunkId, originalWav.riff.chunkId);
   assertEquals(decoded.riff.chunkSize, originalWav.riff.chunkSize);
   assertEquals(decoded.riff.format, originalWav.riff.format);
@@ -308,7 +308,7 @@ Deno.test("WAV package - round-trip integrity", () => {
   assertEquals(decoded.fmt.bitsPerSample, originalWav.fmt.bitsPerSample);
   assertEquals(decoded.data.chunkId, originalWav.data.chunkId);
   assertEquals(decoded.data.chunkSize, originalWav.data.chunkSize);
-  assertEquals(decoded.data.audioData.length, 1000); // Length-prefixed array matches original length
+  assertEquals(decoded.data.audioData.length, 1000); // Exactly chunkSize bytes
 
   // Verify audio data integrity
   for (let i = 0; i < Math.min(100, audioData.length); i++) {
@@ -351,10 +351,10 @@ Deno.test("WAV package - optional chunks", async (t) => {
     const bytesWritten = wavCoder.encode(basicWav, buffer);
     const [decoded, _bytesRead] = wavCoder.decode(buffer);
 
-    assertEquals(bytesWritten, 1050); // 12 (RIFF) + 24 (fmt) + 1012 (data with length prefix)
+    assertEquals(bytesWritten, 1046); // 12 (RIFF) + 26 (fmt) + 1008 (data)
     assertEquals(decoded.riff.chunkId, "RIFF");
     assertEquals(decoded.fmt.audioFormat, 1);
-    assertEquals(decoded.data.audioData.length, 1000); // Length-prefixed array matches original length
+    assertEquals(decoded.data.audioData.length, 1000); // Exactly chunkSize bytes
   });
 });
 
@@ -417,10 +417,10 @@ Deno.test("WAV package - individual chunk coders", async (t) => {
     const bytesWritten = dataCoder.encode(testData, buffer);
     const [decoded, _bytesRead] = dataCoder.decode(buffer);
 
-    assertEquals(bytesWritten, 1012); // 4 (chunkId) + 4 (chunkSize) + 4 (length) + 1000 (audioData)
+    assertEquals(bytesWritten, 1008); // 4 (chunkId) + 4 (chunkSize) + 1000 (audioData)
     assertEquals(decoded.chunkId, "data");
     assertEquals(decoded.chunkSize, 1000);
-    assertEquals(decoded.audioData.length, 1000); // Length-prefixed array matches original length
+    assertEquals(decoded.audioData.length, 1000); // Exactly chunkSize bytes
   });
 
   await t.step("fact chunk coder", () => {
@@ -448,18 +448,18 @@ Deno.test("WAV package - individual chunk coders", async (t) => {
       chunkId: "LIST",
       chunkSize: 20,
       listType: "INFO",
-      data: new Array(12).fill(0),
+      data: new Array(16).fill(0),
     };
 
     const buffer = new Uint8Array(100);
     const bytesWritten = listCoder.encode(testList, buffer);
     const [decoded, _bytesRead] = listCoder.decode(buffer);
 
-    assertEquals(bytesWritten, 28); // 4 (chunkId) + 4 (chunkSize) + 4 (listType) + 4 (length) + 12 (data)
+    assertEquals(bytesWritten, 28); // 4 (chunkId) + 4 (chunkSize) + 4 (listType) + 16 (data)
     assertEquals(decoded.chunkId, "LIST");
     assertEquals(decoded.chunkSize, 20);
     assertEquals(decoded.listType, "INFO");
-    assertEquals(decoded.data.length, 12); // Length-prefixed array
+    assertEquals(decoded.data.length, 16); // chunkSize - 4 (listType)
   });
 });
 
@@ -507,4 +507,138 @@ Deno.test("WAV package - error cases", async (t) => {
       wavCoder.decode(buffer);
     }, Error);
   });
+});
+
+/**
+ * A spec-correct 62-byte RIFF/WAVE file: 8 mono 16-bit PCM samples at 8 kHz.
+ *
+ * The `fmt ` chunk uses the 18-byte extended form (`cbSize` present) because
+ * `fmtChunk()` always codes `cbSize`; see the note on that function.
+ */
+// deno-fmt-ignore
+const wavFixture = (): Uint8Array => Uint8Array.from([
+  0x52, 0x49, 0x46, 0x46, // "RIFF"
+  0x36, 0x00, 0x00, 0x00, // chunkSize 54 (file size - 8)
+  0x57, 0x41, 0x56, 0x45, // "WAVE"
+
+  0x66, 0x6d, 0x74, 0x20, // "fmt "
+  0x12, 0x00, 0x00, 0x00, // chunkSize 18
+  0x01, 0x00,             // audioFormat 1 (PCM)
+  0x01, 0x00,             // numChannels 1
+  0x40, 0x1f, 0x00, 0x00, // sampleRate 8000
+  0x80, 0x3e, 0x00, 0x00, // byteRate 16000
+  0x02, 0x00,             // blockAlign 2
+  0x10, 0x00,             // bitsPerSample 16
+  0x00, 0x00,             // cbSize 0
+
+  0x64, 0x61, 0x74, 0x61, // "data"
+  0x10, 0x00, 0x00, 0x00, // chunkSize 16
+  0x00, 0x00,             // sample 0
+  0xe8, 0x03,             // sample 1000
+  0x18, 0xfc,             // sample -1000
+  0xff, 0x7f,             // sample 32767
+  0x00, 0x80,             // sample -32768
+  0x00, 0x01,             // sample 256
+  0xff, 0xff,             // sample -1
+  0x34, 0x12,             // sample 4660
+]);
+
+Deno.test("WAV package - decodes a real RIFF/WAVE byte fixture", () => {
+  const fixture = wavFixture();
+  const wavCoder = wavFile();
+  const [decoded, bytesRead] = wavCoder.decode(fixture);
+
+  assertEquals(bytesRead, fixture.length);
+
+  assertEquals(decoded.riff, {
+    chunkId: "RIFF",
+    chunkSize: 54,
+    format: "WAVE",
+  });
+  assertEquals(decoded.fmt, {
+    chunkId: "fmt ",
+    chunkSize: 18,
+    audioFormat: 1,
+    numChannels: 1,
+    sampleRate: 8000,
+    byteRate: 16000,
+    blockAlign: 2,
+    bitsPerSample: 16,
+    cbSize: 0,
+  });
+  assertEquals(decoded.data.chunkId, "data");
+  assertEquals(decoded.data.chunkSize, 16);
+  // deno-fmt-ignore
+  assertEquals(decoded.data.audioData, [
+    0x00, 0x00, 0xe8, 0x03, 0x18, 0xfc, 0xff, 0x7f,
+    0x00, 0x80, 0x00, 0x01, 0xff, 0xff, 0x34, 0x12,
+  ]);
+});
+
+Deno.test("WAV package - re-encodes a real RIFF/WAVE byte fixture", () => {
+  const fixture = wavFixture();
+  const wavCoder = wavFile();
+  const [decoded] = wavCoder.decode(fixture);
+
+  const buffer = new Uint8Array(fixture.length);
+  const bytesWritten = wavCoder.encode(decoded, buffer);
+
+  assertEquals(bytesWritten, fixture.length);
+  assertEquals(buffer, fixture);
+});
+
+Deno.test("WAV package - data chunk stops at chunkSize", () => {
+  // deno-fmt-ignore
+  const fixture = Uint8Array.from([
+    0x64, 0x61, 0x74, 0x61, // "data"
+    0x04, 0x00, 0x00, 0x00, // chunkSize 4
+    0x01, 0x02, 0x03, 0x04, // audio samples
+    0xde, 0xad, 0xbe, 0xef, // trailing bytes that belong to the next chunk
+  ]);
+
+  const dataCoder = dataChunk();
+  const [decoded, bytesRead] = dataCoder.decode(fixture);
+
+  assertEquals(bytesRead, 12);
+  assertEquals(decoded.chunkId, "data");
+  assertEquals(decoded.chunkSize, 4);
+  assertEquals(decoded.audioData, [0x01, 0x02, 0x03, 0x04]);
+
+  const buffer = new Uint8Array(12);
+  const bytesWritten = dataCoder.encode(decoded, buffer);
+
+  assertEquals(bytesWritten, 12);
+  assertEquals(buffer, fixture.subarray(0, 12));
+});
+
+Deno.test("WAV package - LIST chunk payload excludes the list type", () => {
+  // deno-fmt-ignore
+  const fixture = Uint8Array.from([
+    0x4c, 0x49, 0x53, 0x54, // "LIST"
+    0x12, 0x00, 0x00, 0x00, // chunkSize 18 (listType + data)
+    0x49, 0x4e, 0x46, 0x4f, // "INFO"
+    0x49, 0x4e, 0x41, 0x4d, // "INAM"
+    0x06, 0x00, 0x00, 0x00, // sub-chunk size 6
+    0x54, 0x69, 0x74, 0x6c, // "Titl"
+    0x65, 0x00,             // "e\0"
+  ]);
+
+  const listCoder = listChunk();
+  const [decoded, bytesRead] = listCoder.decode(fixture);
+
+  assertEquals(bytesRead, fixture.length);
+  assertEquals(decoded.chunkId, "LIST");
+  assertEquals(decoded.chunkSize, 18);
+  assertEquals(decoded.listType, "INFO");
+  assertEquals(decoded.data.length, 14); // chunkSize - 4 (listType)
+  assertEquals(
+    new TextDecoder().decode(Uint8Array.from(decoded.data.slice(8))),
+    "Title\0",
+  );
+
+  const buffer = new Uint8Array(fixture.length);
+  const bytesWritten = listCoder.encode(decoded, buffer);
+
+  assertEquals(bytesWritten, fixture.length);
+  assertEquals(buffer, fixture);
 });

--- a/packages/@binstruct/wav/mod.ts
+++ b/packages/@binstruct/wav/mod.ts
@@ -5,8 +5,11 @@
  * - RIFF chunk with WAVE format identification
  * - Format chunk supporting multiple audio formats (PCM, IEEE float, A-law, μ-law, extensible)
  * - Data chunk with raw audio samples
- * - Optional chunks (fact, LIST, INFO)
- * - Complete WAV file structure with automatic chunk size calculation
+ * - Optional chunks (fact, LIST)
+ * - Complete WAV file structure (RIFF, fmt, data)
+ *
+ * Chunk sizes are taken from the structure as given; they are never recomputed,
+ * and payload lengths are driven by the `chunkSize` field of their chunk.
  *
  * @example Basic WAV file encoding and decoding
  * ```ts
@@ -17,12 +20,12 @@
  * const testWav = {
  *   riff: {
  *     chunkId: "RIFF" as const,
- *     chunkSize: 44,
+ *     chunkSize: 1038, // total file size minus the 8-byte RIFF header
  *     format: "WAVE" as const
  *   },
  *   fmt: {
  *     chunkId: "fmt " as const,
- *     chunkSize: 16,
+ *     chunkSize: 18, // 16 PCM fields plus the 2-byte cbSize
  *     audioFormat: 1, // PCM
  *     numChannels: 1, // Mono
  *     sampleRate: 44100,
@@ -43,6 +46,7 @@
  * const [decodedWav, bytesRead] = wavCoder.decode(buffer);
  *
  * assertEquals(bytesRead, bytesWritten);
+ * assertEquals(bytesWritten, 1046); // 12 (RIFF) + 26 (fmt) + 1008 (data)
  * assertEquals(decodedWav.riff.chunkId, "RIFF");
  * assertEquals(decodedWav.riff.format, "WAVE");
  * assertEquals(decodedWav.fmt.audioFormat, 1);
@@ -51,7 +55,7 @@
  * assertEquals(decodedWav.data.audioData.length, 1000);
  * ```
  *
- * @example IEEE float format with fact chunk
+ * @example IEEE float format
  * ```ts
  * import { assertEquals } from "@std/assert";
  * import { wavFile } from "@binstruct/wav";
@@ -60,7 +64,7 @@
  * const floatWav = {
  *   riff: {
  *     chunkId: "RIFF",
- *     chunkSize: 58,
+ *     chunkSize: 838, // total file size minus the 8-byte RIFF header
  *     format: "WAVE"
  *   },
  *   fmt: {
@@ -86,7 +90,7 @@
  * const [decoded, bytesRead] = floatWavCoder.decode(buffer);
  *
  * assertEquals(bytesRead, bytesWritten);
- * assertEquals(bytesWritten, 850); // 12 (RIFF) + 24 (fmt) + 12 (fact) + 812 (data with length prefix)
+ * assertEquals(bytesWritten, 846); // 12 (RIFF) + 26 (fmt) + 808 (data)
  * assertEquals(decoded.fmt.audioFormat, 3);
  * assertEquals(decoded.fmt.numChannels, 2);
  * assertEquals(decoded.data.audioData.length, 800);
@@ -95,7 +99,16 @@
  * @module @binstruct/wav
  */
 
-import { array, string, struct, u16le, u32le, u8le } from "@hertzg/binstruct";
+import {
+  array,
+  computedRef,
+  ref,
+  string,
+  struct,
+  u16le,
+  u32le,
+  u8le,
+} from "@hertzg/binstruct";
 import type { Coder } from "@hertzg/binstruct";
 
 /**
@@ -141,7 +154,7 @@ export interface FmtChunk {
  *
  * @property chunkId - Always "data" (4 bytes)
  * @property chunkSize - Size of audio data in bytes
- * @property audioData - Raw audio samples as array of bytes
+ * @property audioData - Raw audio samples as array of bytes, exactly `chunkSize` long
  */
 export interface DataChunk {
   chunkId: string;
@@ -166,9 +179,9 @@ export interface FactChunk {
  * Represents an optional LIST chunk structure.
  *
  * @property chunkId - Always "LIST" (4 bytes)
- * @property chunkSize - Size of list data
+ * @property chunkSize - Size of the list type plus the list data
  * @property listType - Type of list (e.g., "INFO")
- * @property data - List data as array of bytes
+ * @property data - List data as array of bytes, exactly `chunkSize - 4` long
  */
 export interface ListChunk {
   chunkId: string;
@@ -235,9 +248,12 @@ export function riffChunk(): Coder<RiffChunk> {
  * Creates a coder for format chunks.
  *
  * Encodes and decodes format chunk structures supporting:
- * - Standard PCM format (16 bytes)
  * - Extended formats with cbSize field (18+ bytes)
  * - Multiple audio format codes (PCM, IEEE float, A-law, μ-law, extensible)
+ *
+ * The `cbSize` field is always encoded and decoded, so the chunk payload is
+ * always 18 bytes and `chunkSize` should be 18. The canonical 16-byte PCM
+ * `fmt ` chunk, which omits `cbSize`, is not supported.
  *
  * @returns A coder that can encode/decode FmtChunk objects
  *
@@ -249,7 +265,7 @@ export function riffChunk(): Coder<RiffChunk> {
  * const fmtCoder = fmtChunk();
  * const testFmt = {
  *   chunkId: "fmt ",
- *   chunkSize: 16,
+ *   chunkSize: 18, // 16 PCM fields plus the 2-byte cbSize
  *   audioFormat: 1, // PCM
  *   numChannels: 2, // Stereo
  *   sampleRate: 44100,
@@ -292,9 +308,11 @@ export function fmtChunk(): Coder<FmtChunk> {
  * Encodes and decodes data chunk structures with:
  * - 4-byte chunk ID ("data")
  * - 4-byte chunk size (little-endian)
- * - Variable-length audio data
+ * - Exactly `chunkSize` bytes of audio data
  *
- * @param lengthOrRef - Optional length specification for audio data
+ * The audio data length is driven by the `chunkSize` field, as required by RIFF:
+ * a `data` chunk carries no length of its own beyond `chunkSize`.
+ *
  * @returns A coder that can encode/decode DataChunk objects
  *
  * @example Basic data chunk encoding and decoding
@@ -313,18 +331,19 @@ export function fmtChunk(): Coder<FmtChunk> {
  * const bytesWritten = dataCoder.encode(testData, buffer);
  * const [decoded, bytesRead] = dataCoder.decode(buffer);
  *
- * assertEquals(bytesRead, 1012);
- * assertEquals(bytesWritten, 1012); // 4 (chunkId) + 4 (chunkSize) + 4 (length) + 1000 (audioData)
+ * assertEquals(bytesRead, 1008);
+ * assertEquals(bytesWritten, 1008); // 4 (chunkId) + 4 (chunkSize) + 1000 (audioData)
  * assertEquals(decoded.chunkId, "data");
  * assertEquals(decoded.chunkSize, 1000);
  * assertEquals(decoded.audioData.length, 1000); // Uses chunkSize reference
  * ```
  */
 export function dataChunk(): Coder<DataChunk> {
+  const chunkSize = u32le();
   return struct({
     chunkId: string(4),
-    chunkSize: u32le(),
-    audioData: array(u8le(), u32le()),
+    chunkSize,
+    audioData: array(u8le(), ref(chunkSize)),
   });
 }
 
@@ -376,9 +395,11 @@ export function factChunk(): Coder<FactChunk> {
  * - 4-byte chunk ID ("LIST")
  * - 4-byte chunk size
  * - 4-byte list type
- * - Variable-length list data
+ * - Exactly `chunkSize - 4` bytes of list data
  *
- * @param lengthOrRef - Optional length specification for list data
+ * A RIFF `LIST` chunk counts its list type towards `chunkSize`, so the payload
+ * that follows the list type is four bytes shorter than `chunkSize`.
+ *
  * @returns A coder that can encode/decode ListChunk objects
  *
  * @example Basic LIST chunk encoding and decoding
@@ -391,7 +412,7 @@ export function factChunk(): Coder<FactChunk> {
  *   chunkId: "LIST",
  *   chunkSize: 20,
  *   listType: "INFO",
- *   data: new Array(12).fill(0)
+ *   data: new Array(16).fill(0)
  * };
  *
  * const buffer = new Uint8Array(100);
@@ -399,33 +420,34 @@ export function factChunk(): Coder<FactChunk> {
  * const [decoded, bytesRead] = listCoder.decode(buffer);
  *
  * assertEquals(bytesRead, 28);
- * assertEquals(bytesWritten, 28); // 4 (chunkId) + 4 (chunkSize) + 4 (listType) + 4 (length) + 12 (data)
+ * assertEquals(bytesWritten, 28); // 4 (chunkId) + 4 (chunkSize) + 4 (listType) + 16 (data)
  * assertEquals(decoded.chunkId, "LIST");
  * assertEquals(decoded.chunkSize, 20);
  * assertEquals(decoded.listType, "INFO");
- * assertEquals(decoded.data.length, 12); // Uses chunkSize reference
+ * assertEquals(decoded.data.length, 16); // chunkSize - 4 (listType)
  * ```
  */
 export function listChunk(): Coder<ListChunk> {
+  const chunkSize = u32le();
   return struct({
     chunkId: string(4),
-    chunkSize: u32le(),
+    chunkSize,
     listType: string(4),
-    data: array(u8le(), u32le()),
+    data: array(u8le(), computedRef([ref(chunkSize)], (size) => size - 4)),
   });
 }
 
 /**
  * Creates a coder for complete WAV files.
  *
- * Encodes and decodes complete WAV file structures including:
+ * Encodes and decodes WAV files laid out as exactly three chunks in this order:
  * - RIFF header chunk
  * - Format chunk
- * - Optional fact chunk (for non-PCM formats)
- * - Optional LIST chunk (for metadata)
  * - Data chunk with audio samples
  *
- * The coder handles variable chunk ordering and optional chunks automatically.
+ * Files carrying additional chunks (`fact`, `LIST`) or a different chunk order
+ * are not handled; compose {@link factChunk} and {@link listChunk} manually for
+ * those.
  *
  * @returns A coder that can encode/decode WavFile objects
  *
@@ -438,12 +460,12 @@ export function listChunk(): Coder<ListChunk> {
  * const testWav = {
  *   riff: {
  *     chunkId: "RIFF" as const,
- *     chunkSize: 44,
+ *     chunkSize: 1038, // total file size minus the 8-byte RIFF header
  *     format: "WAVE" as const
  *   },
  *   fmt: {
  *     chunkId: "fmt " as const,
- *     chunkSize: 16,
+ *     chunkSize: 18, // 16 PCM fields plus the 2-byte cbSize
  *     audioFormat: 1, // PCM
  *     numChannels: 1, // Mono
  *     sampleRate: 44100,
@@ -464,7 +486,7 @@ export function listChunk(): Coder<ListChunk> {
  * const [decoded, bytesRead] = wavCoder.decode(buffer);
  *
  * assertEquals(bytesRead, bytesWritten);
- * assertEquals(bytesWritten, 1050); // 12 (RIFF) + 24 (fmt) + 1012 (data with length prefix)
+ * assertEquals(bytesWritten, 1046); // 12 (RIFF) + 26 (fmt) + 1008 (data)
  * assertEquals(decoded.riff.chunkId, "RIFF");
  * assertEquals(decoded.riff.format, "WAVE");
  * assertEquals(decoded.fmt.audioFormat, 1);


### PR DESCRIPTION
Closes #223

## Problem

`dataChunk()` and `listChunk()` passed a `u32le()` coder as `array()`'s second argument. `array()` dispatches on that argument: a **Coder** means length-prefixed, a **number/ref** means fixed-length. So both chunks wrote four spurious bytes of count before the payload and, on decode, consumed four bytes of audio as that count. Real RIFF has no such field, so `wavFile()` could neither read nor write an actual `.wav`. Every existing test was a self-round-trip, so the extra field cancelled out and nothing caught it.

## Changes

- **`dataChunk()`** — `audioData` is now `array(u8le(), ref(chunkSize))`, driven by the already-decoded `chunkSize` field per the forward-only reference pattern.
- **`listChunk()`** — same treatment, **minus four**: RIFF counts the list type towards a `LIST` chunk's `chunkSize`, so the payload after `listType` is `chunkSize - 4`. A plain `ref(chunkSize)` here would have over-read by 4 bytes on every real INFO list.
- **Corrected byte counts** in every JSDoc example and test: `1012`→`1008`, `1050`→`1046` (×7), `850`→`846`, `2050`→`2046`. The breakdown comments also claimed "24 (fmt)" when `fmtChunk()` writes 26, and the float example invented a "12 (fact)" term for a chunk that isn't there.
- **Made example data self-consistent** — `riff.chunkSize` values (`44`, `58`) were meaningless for the files they described (now file size − 8), and `fmt.chunkSize` is `18` since the coder always writes `cbSize`.
- **Corrected two false doc claims** — `wavFile()` advertised optional fact/LIST chunks and "variable chunk ordering handled automatically" (it is a fixed RIFF+fmt+data struct), and the module header claimed "automatic chunk size calculation" (sizes are taken as given).

## Tests

Four new tests, none of them self-round-trips:

- a hand-built 62-byte `// deno-fmt-ignore` RIFF/WAVE fixture (8 mono 16-bit PCM samples @ 8 kHz), decoded and asserted field-by-field, then re-encoded and compared byte-for-byte against the original array
- a `data` chunk fixture with trailing bytes, proving decode stops exactly at `chunkSize`
- a real `LIST`/`INFO` fixture (`INAM` = `"Title\0"`), proving the `- 4`

`deno task lint` and `deno task test` both pass (the 3 `@binstruct/cli` failures on `main` are pre-existing and untouched). The `@binstruct/wav` package alone is 20 passed / 0 failed including all 8 JSDoc examples.

## Known gap, not fixed here

`fmtChunk()` always codes `cbSize`, so its payload is always 18 bytes and it cannot read the canonical **16-byte** PCM `fmt ` chunk most real `.wav` files carry — which is why the fixture above uses the 18-byte extended form. That is a different class of bug (needs a conditional/`chunkSize`-driven field and changes `FmtChunk`'s shape), so it wants its own issue. Until it lands, `wavFile()` still can't read a canonical 44-byte-header PCM file.

Separately, `packages/@hertzg/binstruct/mod.ts` (~line 143) has the **identical** `array(u8le(), u32le())` mistake in the WAV example in its module JSDoc, comment and all. Left alone here so the commit doesn't get misattributed across packages by Release Please — it needs its own `fix(@hertzg/binstruct)` docs commit.
