### PR TITLE
fix(@hertzg/binstruct): publish arrayFL values to the ref map

### DIFF
--- a/packages/@hertzg/binstruct/array/fixed-length.ts
+++ b/packages/@hertzg/binstruct/array/fixed-length.ts
@@ -1,5 +1,6 @@
 import { type Coder, createContext, kCoderKind } from "../core.ts";
 import { isValidLength, type LengthOrRef, lengthRefGet } from "../length.ts";
+import { refSetValue } from "../ref/ref.ts";
 
 /**
  * Symbol identifier for fixed-length array coders.
@@ -95,10 +96,13 @@ export function arrayFL<TDecoded>(
   elementType: Coder<TDecoded>,
   lengthOrRef: LengthOrRef,
 ): Coder<TDecoded[]> {
-  return {
+  let self: Coder<TDecoded[]>;
+  return self = {
     [kCoderKind]: kKindArrayFL,
     encode: (decoded, target, context) => {
       const ctx = context ?? createContext("encode");
+      refSetValue(ctx, self, decoded);
+
       const len = lengthRefGet(ctx, lengthOrRef) ?? decoded.length;
 
       if (!isValidLength(len)) {
@@ -134,7 +138,9 @@ export function arrayFL<TDecoded>(
         );
       }
 
-      const decoded = new Array<TDecoded>();
+      const decoded = new Array<TDecoded>(len);
+      refSetValue(ctx, self, decoded);
+
       let cursor = 0;
       for (let i = 0; i < len; i++) {
         const [element, bytesRead] = elementType.decode(


### PR DESCRIPTION
Stack 1/5 — base `main`.

Every other coder in the package calls `refSetValue` on both `encode` and `decode`, so its decoded value can be reached with `ref()`. `arrayFL` was the sole exception and never bound `self`:

```ts
ref(arrayLP(u8(), u8()))  // resolves
ref(arrayFL(u8(), 3))     // throws "Ref not found in context"
```

Because `array()` dispatches between the two on the type of its second argument, whether an array coder was ref-able depended on how its length happened to be expressed, with nothing in the types or docs saying so.

The change is additive — `arrayFL` is now ref-able where it previously threw; nothing that worked before behaves differently.

Also pre-sizes the decode array from the already-resolved length, matching `arrayLP`.

Found by `/simplify`; the reuse and altitude passes independently flagged it as the one place the publish-yourself invariant is enforced only by convention.