### PR TITLE
chore(@hertzg/binstruct): collapse duplicated encode and decode bodies

### DIFF
--- a/packages/@hertzg/binstruct/array/conditional-while.ts
+++ b/packages/@hertzg/binstruct/array/conditional-while.ts
@@ -16,11 +16,9 @@ export const kKindArrayWhile = Symbol("arrayWhile");
  *
  * @param params - Object containing all parameters for the condition
  * @param params.index - Current iteration index (0-based)
- * @param params.element - Current element being processed (null during decode when element not yet available)
+ * @param params.array - Elements accumulated so far (being filled during decode)
+ * @param params.buffer - Remaining buffer data from the current cursor position
  * @param params.context - Encoding/decoding context
- * @param params.cursor - Current position in the buffer
- * @param params.remaining - Remaining buffer data from cursor position
- * @param params.args - Additional arguments passed to the condition function
  * @returns True to continue processing, false to stop
  */
 export type ArrayWhileCondition<TDecoded> = (params: {
@@ -42,7 +40,6 @@ export type ArrayWhileCondition<TDecoded> = (params: {
  *
  * @param elementType - The coder for individual array elements
  * @param condition - Function that determines when to continue processing
- * @param args - Additional arguments to pass to the condition function
  * @returns A Coder that can encode/decode arrays using the custom condition
  */
 
@@ -60,21 +57,18 @@ export function arrayWhile<TDecoded>(
       refSetValue(ctx, self, decoded);
 
       for (let i = 0; i < decoded.length; i++) {
+        const remaining = target.subarray(cursor);
         if (
           !condition({
             index: i,
             array: decoded,
-            buffer: target.subarray(cursor),
+            buffer: remaining,
             context: ctx,
           })
         ) {
           break;
         }
-        cursor += elementType.encode(
-          decoded[i],
-          target.subarray(cursor),
-          ctx,
-        );
+        cursor += elementType.encode(decoded[i], remaining, ctx);
       }
 
       return cursor;
@@ -89,21 +83,19 @@ export function arrayWhile<TDecoded>(
       let i = 0;
 
       while (cursor < encoded.length) {
+        const remaining = encoded.subarray(cursor);
         if (
           !condition({
             index: i,
             array: decoded,
-            buffer: encoded.subarray(cursor),
+            buffer: remaining,
             context: ctx,
           })
         ) {
           break;
         }
 
-        const [element, bytesRead] = elementType.decode(
-          encoded.subarray(cursor),
-          ctx,
-        );
+        const [element, bytesRead] = elementType.decode(remaining, ctx);
         cursor += bytesRead;
         decoded[i] = element;
         i++;

--- a/packages/@hertzg/binstruct/bits/bit-struct.ts
+++ b/packages/@hertzg/binstruct/bits/bit-struct.ts
@@ -140,7 +140,14 @@ export function bitStruct<T extends BitSchema>(
 ): Coder<BitStructDecoded<T>> {
   const fields = Object.entries(schema) as [keyof T, number][];
 
-  // Validate each field's bit count
+  // Validate each field's bit count and resolve its position once, since the
+  // schema is fixed for the lifetime of the coder.
+  const layout: {
+    key: keyof T;
+    bitCount: number;
+    byteOffset: number;
+    bitOffset: number;
+  }[] = [];
   let totalBits = 0;
   for (const [key, bitCount] of fields) {
     if (
@@ -152,6 +159,12 @@ export function bitStruct<T extends BitSchema>(
         }": ${bitCount}. Must be integer 1-32.`,
       );
     }
+    layout.push({
+      key,
+      bitCount,
+      byteOffset: totalBits >>> 3,
+      bitOffset: totalBits & 7,
+    });
     totalBits += bitCount;
   }
 
@@ -178,11 +191,8 @@ export function bitStruct<T extends BitSchema>(
       const ctx = context ?? createContext("encode");
       const view = new BitDataView(target);
 
-      let byteOffset = 0;
-      let bitOffset = 0;
-
       // Process fields in declaration order
-      for (const [key, bitCount] of fields) {
+      for (const { key, bitCount, byteOffset, bitOffset } of layout) {
         const value = decoded[key];
 
         // Validate value fits in bitCount bits
@@ -196,13 +206,6 @@ export function bitStruct<T extends BitSchema>(
         }
 
         view.setBits(byteOffset, bitOffset, value, bitCount);
-
-        // Advance bit position
-        bitOffset += bitCount;
-        if (bitOffset >= 8) {
-          byteOffset += Math.floor(bitOffset / 8);
-          bitOffset %= 8;
-        }
       }
 
       // Store entire struct result in context for refs
@@ -223,19 +226,9 @@ export function bitStruct<T extends BitSchema>(
       const view = new BitDataView(encoded);
       const result = {} as BitStructDecoded<T>;
 
-      let byteOffset = 0;
-      let bitOffset = 0;
-
       // Process fields in declaration order
-      for (const [key, bitCount] of fields) {
+      for (const { key, bitCount, byteOffset, bitOffset } of layout) {
         result[key] = view.getBits(byteOffset, bitOffset, bitCount);
-
-        // Advance bit position
-        bitOffset += bitCount;
-        if (bitOffset >= 8) {
-          byteOffset += Math.floor(bitOffset / 8);
-          bitOffset %= 8;
-        }
       }
 
       // Store entire struct result in context for refs

--- a/packages/@hertzg/binstruct/refine/switch.ts
+++ b/packages/@hertzg/binstruct/refine/switch.ts
@@ -336,6 +336,30 @@ export function refineSwitch<
 ): Coder<RefinedUnion<TRefiners>> {
   const refinerKeys = Object.keys(refiners);
 
+  const selectRefiner = (
+    key: keyof TRefiners | null,
+    selectorName: "refine" | "unrefine",
+  ) => {
+    if (key === null) {
+      throw new Error(
+        `refineSwitch: selector.${selectorName} returned null for value. ` +
+          `No refiner selected. Available refiners: ${refinerKeys.join(", ")}`,
+      );
+    }
+
+    const refiner = refiners[key as string];
+    if (!refiner) {
+      throw new Error(
+        `refineSwitch: Invalid refiner key "${
+          String(key)
+        }" returned by selector.${selectorName}. ` +
+          `Available refiners: ${refinerKeys.join(", ")}`,
+      );
+    }
+
+    return refiner;
+  };
+
   let self: Coder<RefinedUnion<TRefiners>>;
   return self = {
     [kCoderKind]: kKindRefineSwitch,
@@ -344,25 +368,7 @@ export function refineSwitch<
       refSetValue(ctx, self, refined);
 
       // Select which refiner to use for encoding
-      const key = selector.unrefine(refined, ctx);
-      if (key === null) {
-        throw new Error(
-          `refineSwitch: selector.unrefine returned null for value. ` +
-            `No refiner selected. Available refiners: ${
-              refinerKeys.join(", ")
-            }`,
-        );
-      }
-
-      const refiner = refiners[key as string];
-      if (!refiner) {
-        throw new Error(
-          `refineSwitch: Invalid refiner key "${
-            String(key)
-          }" returned by selector.unrefine. ` +
-            `Available refiners: ${refinerKeys.join(", ")}`,
-        );
-      }
+      const refiner = selectRefiner(selector.unrefine(refined, ctx), "unrefine");
 
       // Unrefine the value back to base type
       // deno-lint-ignore no-explicit-any
@@ -378,25 +384,7 @@ export function refineSwitch<
       const [base, bytesRead] = baseCoder.decode(buffer, ctx);
 
       // Select which refiner to use for decoding
-      const key = selector.refine(base, ctx);
-      if (key === null) {
-        throw new Error(
-          `refineSwitch: selector.refine returned null for value. ` +
-            `No refiner selected. Available refiners: ${
-              refinerKeys.join(", ")
-            }`,
-        );
-      }
-
-      const refiner = refiners[key as string];
-      if (!refiner) {
-        throw new Error(
-          `refineSwitch: Invalid refiner key "${
-            String(key)
-          }" returned by selector.refine. ` +
-            `Available refiners: ${refinerKeys.join(", ")}`,
-        );
-      }
+      const refiner = selectRefiner(selector.refine(base, ctx), "refine");
 
       // Refine the base value to the target type
       const refined = refiner.refine(base, ctx);


### PR DESCRIPTION
Stack 2/5 — base `fix/binstruct-arrayfl-refs` (#228).

Three coders carried the same logic twice, once per direction.

- **`refineSwitch`** had two ~20-line refiner-dispatch blocks, character-identical apart from `"refine"`/`"unrefine"` in the error strings. Extracted `selectRefiner(key, selectorName)`; messages are unchanged.
- **`bitStruct`** duplicated the bit-position advance block and re-derived every field offset on each call, even though the schema is fixed at construction. Positions now resolve once into a `layout` array next to the existing validation loop.
- **`arrayWhile`** built two identical `subarray` views per iteration — one for the condition callback, one for the element coder.

Also corrects the `ArrayWhileCondition` docs, which listed four parameters (`element`, `cursor`, `remaining`, `args`) the type does not have, plus an `@param args` on a two-parameter function.

No behavior change.