### PR TITLE
chore(@hertzg/binstruct): drop redundant work in numeric and string coders

### DIFF
--- a/packages/@hertzg/binstruct/numeric/dataview.ts
+++ b/packages/@hertzg/binstruct/numeric/dataview.ts
@@ -59,15 +59,20 @@ export function dataViewType<TDecoded extends number | bigint>(
   endianness: Endianness,
   kind: symbol,
 ): Coder<TDecoded> {
-  const bits = Number((type.match(/[0-9]+$/)?.[0])!);
-
-  if (isNaN(bits)) {
-    throw new Error(`Unable to infer size from type ${type}`);
-  }
-
-  const bytes = Math.trunc(bits / 8);
-
-  const methodSuffix = `${type}` as const;
+  const byteSizes: Record<DataViewMethodSuffixes, number> = {
+    Int8: 1,
+    Uint8: 1,
+    Int16: 2,
+    Uint16: 2,
+    Float16: 2,
+    Int32: 4,
+    Uint32: 4,
+    Float32: 4,
+    BigInt64: 8,
+    BigUint64: 8,
+    Float64: 8,
+  };
+  const bytes = byteSizes[type];
 
   let self: Coder<TDecoded>;
   return self = {
@@ -80,27 +85,19 @@ export function dataViewType<TDecoded extends number | bigint>(
         target.byteOffset,
         target.byteLength,
       );
-      switch (methodSuffix) {
+      switch (type) {
         case "Uint8":
         case "Int8":
-          dataView[`set${methodSuffix}`](0, value as number);
+          dataView[`set${type}`](0, value as number);
           break;
 
         case "BigUint64":
         case "BigInt64":
-          dataView[`set${methodSuffix}`](
-            0,
-            value as bigint,
-            endianness === "le",
-          );
+          dataView[`set${type}`](0, value as bigint, endianness === "le");
           break;
 
         default:
-          dataView[`set${methodSuffix}`](
-            0,
-            value as number,
-            endianness === "le",
-          );
+          dataView[`set${type}`](0, value as number, endianness === "le");
           break;
       }
       return bytes;
@@ -117,17 +114,14 @@ export function dataViewType<TDecoded extends number | bigint>(
       );
 
       let value: TDecoded;
-      switch (methodSuffix) {
+      switch (type) {
         case "Uint8":
         case "Int8":
-          value = dataView[`get${methodSuffix}`](0) as TDecoded;
+          value = dataView[`get${type}`](0) as TDecoded;
           break;
 
         default:
-          value = dataView[`get${methodSuffix}`](
-            0,
-            endianness === "le",
-          ) as TDecoded;
+          value = dataView[`get${type}`](0, endianness === "le") as TDecoded;
           break;
       }
 

--- a/packages/@hertzg/binstruct/string/fixed-length.ts
+++ b/packages/@hertzg/binstruct/string/fixed-length.ts
@@ -91,20 +91,23 @@ export function stringFL(
   decoderEncoding: string = "utf-8",
   decoderOptions: TextDecoderOptions = {},
 ): Coder<string> {
+  const decoderInit: TextDecoderOptions = {
+    fatal: true,
+    ignoreBOM: true,
+    ...decoderOptions,
+  };
+
   let self: Coder<string>;
   return self = {
     [kCoderKind]: kKindStringFL,
     encode: (decoded, target, context) => {
       const ctx = context ?? createContext("encode");
 
-      let len: number;
-      if (byteLength == null) {
-        len = decoded.length;
-      } else {
-        len = lengthRefGet(ctx, byteLength) ?? decoded.length;
-      }
+      const len = (byteLength == null
+        ? undefined
+        : lengthRefGet(ctx, byteLength)) ?? decoded.length;
 
-      if (len != null && !isValidLength(len)) {
+      if (!isValidLength(len)) {
         throw new Error(
           `Invalid length: ${len}. Must be a non-negative integer.`,
         );
@@ -118,8 +121,9 @@ export function stringFL(
     },
     decode: (encoded, context) => {
       const ctx = context ?? createContext("decode");
-      const len = lengthRefGet(ctx, byteLength ?? encoded.length) ??
-        encoded.length;
+      const len = (byteLength == null
+        ? undefined
+        : lengthRefGet(ctx, byteLength)) ?? encoded.length;
 
       if (!isValidLength(len)) {
         throw new Error(
@@ -127,14 +131,9 @@ export function stringFL(
         );
       }
 
-      const stringBytes = encoded.subarray(0, len ?? undefined);
-      const decoded = new TextDecoder(decoderEncoding, {
-        fatal: true,
-        ignoreBOM: true,
-        ...decoderOptions,
-      }).decode(
-        stringBytes,
-      );
+      const stringBytes = encoded.subarray(0, len);
+      const decoded = new TextDecoder(decoderEncoding, decoderInit)
+        .decode(stringBytes);
 
       refSetValue(ctx, self, decoded);
 


### PR DESCRIPTION
Stack 3/5 — base `chore/binstruct-dedupe-coder-bodies` (#229).

**`dataViewType`** derived each type's byte width by running a regex over the type *name*, guarded by an `isNaN` throw and a non-null assertion — even though the parameter is a closed 11-member union:

```ts
const bits = Number((type.match(/[0-9]+$/)?.[0])!);
if (isNaN(bits)) throw new Error(`Unable to infer size from type ${type}`);
```

A lookup table gives the same answer statically, and the unreachable throw goes away with it. `methodSuffix` was a template-literal copy of `type`.

**`stringFL`** rebuilt its `TextDecoder` options object on every decode from values fixed at construction; it is now built once in the factory (a plain config object, not an instance). Its length handling also carried three guards against `null` on locals typed `number`: `len != null &&`, a trailing `?? undefined`, and a decode path applying the same fallback both as the argument and to the result.

No behavior change.