### PR TITLE
chore(@hertzg/binstruct): use the exported Endianness type in numeric factories

### DIFF
--- a/packages/@hertzg/binstruct/numeric/floats.ts
+++ b/packages/@hertzg/binstruct/numeric/floats.ts
@@ -91,6 +91,7 @@
 
 import type { Coder } from "../core.ts";
 import { dataViewType } from "./dataview.ts";
+import type { Endianness } from "./numeric.ts";
 
 // Symbol definitions for floating-point types
 const kKindF16BE = Symbol("f16be");
@@ -142,7 +143,7 @@ const kKindF64LE = Symbol("f64le");
  * assertEquals(bytesReadLE, 2);
  * ```
  */
-export function f16(endianness: "be" | "le" = "be"): Coder<number> {
+export function f16(endianness: Endianness = "be"): Coder<number> {
   return dataViewType(
     "Float16",
     endianness,
@@ -192,7 +193,7 @@ export function f16(endianness: "be" | "le" = "be"): Coder<number> {
  * assertEquals(bytesReadLE, 4);
  * ```
  */
-export function f32(endianness: "be" | "le" = "be"): Coder<number> {
+export function f32(endianness: Endianness = "be"): Coder<number> {
   return dataViewType(
     "Float32",
     endianness,
@@ -242,7 +243,7 @@ export function f32(endianness: "be" | "le" = "be"): Coder<number> {
  * assertEquals(bytesReadLE, 8);
  * ```
  */
-export function f64(endianness: "be" | "le" = "be"): Coder<number> {
+export function f64(endianness: Endianness = "be"): Coder<number> {
   return dataViewType(
     "Float64",
     endianness,

--- a/packages/@hertzg/binstruct/numeric/signed.ts
+++ b/packages/@hertzg/binstruct/numeric/signed.ts
@@ -88,6 +88,7 @@
 
 import type { Coder } from "../core.ts";
 import { dataViewType } from "./dataview.ts";
+import type { Endianness } from "./numeric.ts";
 
 // Symbol definitions for signed integer types
 const kKindS8 = Symbol("s8");
@@ -138,7 +139,7 @@ const kKindS64LE = Symbol("s64le");
  * assertEquals(bytesReadLE, 1);
  * ```
  */
-export function s8(endianness: "be" | "le" = "be"): Coder<number> {
+export function s8(endianness: Endianness = "be"): Coder<number> {
   return dataViewType("Int8", endianness, kKindS8);
 }
 
@@ -182,7 +183,7 @@ export function s8(endianness: "be" | "le" = "be"): Coder<number> {
  * assertEquals(bytesReadLE, 2);
  * ```
  */
-export function s16(endianness: "be" | "le" = "be"): Coder<number> {
+export function s16(endianness: Endianness = "be"): Coder<number> {
   return dataViewType(
     "Int16",
     endianness,
@@ -230,7 +231,7 @@ export function s16(endianness: "be" | "le" = "be"): Coder<number> {
  * assertEquals(bytesReadLE, 4);
  * ```
  */
-export function s32(endianness: "be" | "le" = "be"): Coder<number> {
+export function s32(endianness: Endianness = "be"): Coder<number> {
   return dataViewType(
     "Int32",
     endianness,
@@ -279,7 +280,7 @@ export function s32(endianness: "be" | "le" = "be"): Coder<number> {
  * assertEquals(bytesReadLE, 8);
  * ```
  */
-export function s64(endianness: "be" | "le" = "be"): Coder<bigint> {
+export function s64(endianness: Endianness = "be"): Coder<bigint> {
   return dataViewType(
     "BigInt64",
     endianness,

--- a/packages/@hertzg/binstruct/numeric/unsigned.ts
+++ b/packages/@hertzg/binstruct/numeric/unsigned.ts
@@ -91,6 +91,7 @@
 
 import type { Coder } from "../core.ts";
 import { dataViewType } from "./dataview.ts";
+import type { Endianness } from "./numeric.ts";
 
 // Symbol definitions for unsigned integer types
 const kKindU8 = Symbol("u8");
@@ -141,7 +142,7 @@ const kKindU64LE = Symbol("u64le");
  * assertEquals(bytesReadLE, 1);
  * ```
  */
-export function u8(endianness: "be" | "le" = "be"): Coder<number> {
+export function u8(endianness: Endianness = "be"): Coder<number> {
   return dataViewType("Uint8", endianness, kKindU8);
 }
 
@@ -185,7 +186,7 @@ export function u8(endianness: "be" | "le" = "be"): Coder<number> {
  * assertEquals(bytesReadLE, 2);
  * ```
  */
-export function u16(endianness: "be" | "le" = "be"): Coder<number> {
+export function u16(endianness: Endianness = "be"): Coder<number> {
   return dataViewType(
     "Uint16",
     endianness,
@@ -233,7 +234,7 @@ export function u16(endianness: "be" | "le" = "be"): Coder<number> {
  * assertEquals(bytesReadLE, 4);
  * ```
  */
-export function u32(endianness: "be" | "le" = "be"): Coder<number> {
+export function u32(endianness: Endianness = "be"): Coder<number> {
   return dataViewType(
     "Uint32",
     endianness,
@@ -282,7 +283,7 @@ export function u32(endianness: "be" | "le" = "be"): Coder<number> {
  * assertEquals(bytesReadLE, 8);
  * ```
  */
-export function u64(endianness: "be" | "le" = "be"): Coder<bigint> {
+export function u64(endianness: Endianness = "be"): Coder<bigint> {
   return dataViewType(
     "BigUint64",
     endianness,


### PR DESCRIPTION
Stack 4/5 — base `chore/binstruct-redundant-per-call-work` (#230).

`Endianness` is declared and exported from `numeric.ts`, and `dataview.ts` imports it, but the eleven public factories (`u8`–`u64`, `s8`–`s64`, `f16`–`f64`) spelled out `"be" | "le"` inline.

The named type therefore appeared nowhere in the signatures that use it, so `deno doc` showed consumers a bare union, and widening it would have been an eleven-site edit the compiler could not point at.

Type-identical; no behavior change.