### PR TITLE
chore(@hertzg/binstruct): remove vestigial locals and assignments

### DIFF
--- a/packages/@hertzg/binstruct/array/length-prefixed.ts
+++ b/packages/@hertzg/binstruct/array/length-prefixed.ts
@@ -68,7 +68,7 @@ export function arrayLP<TDecoded>(
   lengthType: Coder<number>,
 ): Coder<TDecoded[]> {
   let self: Coder<TDecoded[]>;
-  return self = self = {
+  return self = {
     [kCoderKind]: kKindArrayLP,
     encode: (decoded, target, context) => {
       const ctx = context ?? createContext("encode");

--- a/packages/@hertzg/binstruct/bits/view.ts
+++ b/packages/@hertzg/binstruct/bits/view.ts
@@ -80,7 +80,6 @@ export class BitDataView {
     count: number,
   ): void {
     let remaining = count;
-    const val = value;
     let currentByteOffset = byteOffset;
     let currentBitOffset = bitOffset;
 
@@ -91,11 +90,10 @@ export class BitDataView {
 
       // Extract the bits to write from value
       const shift = remaining - bitsToWrite;
-      const bits = (val >> shift) & ((1 << bitsToWrite) - 1);
+      const bits = (value >> shift) & ((1 << bitsToWrite) - 1);
 
       // Place bits in current byte (MSB first)
-      const currentByte = this.buffer[currentByteOffset] || 0;
-      this.buffer[currentByteOffset] = currentByte |
+      this.buffer[currentByteOffset] = this.buffer[currentByteOffset] |
         (bits << (bitsAvailable - bitsToWrite));
 
       currentBitOffset += bitsToWrite;

--- a/packages/@hertzg/binstruct/helpers.ts
+++ b/packages/@hertzg/binstruct/helpers.ts
@@ -186,12 +186,10 @@ export function encode<T>(
     return target.subarray(0, bytesWritten);
   }
 
-  const buffer = autoGrowBuffer((buffer) => {
+  return autoGrowBuffer((buffer) => {
     const bytesWritten = coder.encode(data, buffer, ctx);
     return buffer.subarray(0, bytesWritten);
   }, autogrowOptions);
-
-  return buffer;
 }
 
 /**

--- a/packages/@hertzg/binstruct/refine/refine.ts
+++ b/packages/@hertzg/binstruct/refine/refine.ts
@@ -180,12 +180,11 @@ export function refine<
       ) => {
         const ctx = context ?? createContext("encode");
         refSetValue(ctx, self, refined);
-        const bytesWritten = coder.encode(
+        return coder.encode(
           refiner.unrefine(refined, ctx, ...args),
           buffer,
           ctx,
         );
-        return bytesWritten;
       },
       decode: (buffer: Uint8Array, context?: Context) => {
         const ctx = context ?? createContext("decode");


### PR DESCRIPTION
Stack 5/5 — base `chore/binstruct-endianness-type` (#231).

- `arrayLP` read `return self = self = {`, a double assignment left over from copy-paste; every sibling coder writes it once.
- `BitDataView.setBits` aliased its `value` parameter to `val`, and read `this.buffer[i] || 0` on an index the caller's `totalBytes` contract already bounds.
- `encode()` and `refine()`'s encode assigned a result to a local used only by the next line's return.

No behavior change.