### PR TITLE
chore(@hertzg/binstruct): replace hand-rolled test doubles with @std/testing/mock

### DIFF
--- a/packages/@hertzg/binstruct/buffer.test.ts
+++ b/packages/@hertzg/binstruct/buffer.test.ts
@@ -1,5 +1,6 @@
-import { assertEquals, assertThrows } from "@std/assert";
-import { autoGrowBuffer, type AutogrowOptions } from "./buffer.ts";
+import { assertEquals, assertLessOrEqual, assertThrows } from "@std/assert";
+import { assertSpyCalls, spy } from "@std/testing/mock";
+import { autoGrowBuffer } from "./buffer.ts";
 
 Deno.test("autoGrowBuffer - basic functionality", () => {
   const data = new Uint8Array(10000);
@@ -74,19 +75,17 @@ Deno.test("autoGrowBuffer - data integrity", () => {
 });
 
 Deno.test("autoGrowBuffer - growth behavior", () => {
-  let callCount = 0;
   const requiredSize = 20000;
 
-  const result = autoGrowBuffer((buffer) => {
-    callCount++;
+  const fill = spy((buffer: Uint8Array) => {
     if (buffer.length < requiredSize) {
       throw new RangeError("Buffer too small");
     }
-    return `success after ${callCount} attempts`;
+    return "encoded";
   });
 
-  assertEquals(result, "success after 4 attempts");
-  assertEquals(callCount, 4);
+  assertEquals(autoGrowBuffer(fill), "encoded");
+  assertSpyCalls(fill, 4);
 });
 
 Deno.test("autoGrowBuffer - invalid configuration", () => {
@@ -118,74 +117,18 @@ Deno.test("autoGrowBuffer - return type flexibility", () => {
   assertEquals(objectResult, { success: true });
 });
 
-Deno.test("AutogrowOptions interface", () => {
-  const options: AutogrowOptions = {
-    initialSize: 1024,
-    maxByteLength: 1024 * 1024,
-    growthFactor: 1.5,
-  };
-
-  assertEquals(options.initialSize, 1024);
-  assertEquals(options.maxByteLength, 1024 * 1024);
-  assertEquals(options.growthFactor, 1.5);
-});
-
 Deno.test("autoGrowBuffer - growth factor validation", () => {
-  // Test growth factor = 1 (should be rejected)
-  assertThrows(
-    () => {
-      autoGrowBuffer(
-        (_buffer) => "success",
-        {
-          growthFactor: 1,
-        },
-      );
-    },
-    Error,
-    "Growth factor must be greater than 1",
-  );
+  // Anything at or below 1 fails to grow the buffer, so it is rejected up front
+  // rather than looping forever.
+  const rejected = [1, 0.5, 0, -1];
 
-  // Test growth factor < 1 (should be rejected)
-  assertThrows(
-    () => {
-      autoGrowBuffer(
-        (_buffer) => "success",
-        {
-          growthFactor: 0.5,
-        },
-      );
-    },
-    Error,
-    "Growth factor must be greater than 1",
-  );
-
-  // Test growth factor = 0 (should be rejected)
-  assertThrows(
-    () => {
-      autoGrowBuffer(
-        (_buffer) => "success",
-        {
-          growthFactor: 0,
-        },
-      );
-    },
-    Error,
-    "Growth factor must be greater than 1",
-  );
-
-  // Test growth factor < 0 (should be rejected)
-  assertThrows(
-    () => {
-      autoGrowBuffer(
-        (_buffer) => "success",
-        {
-          growthFactor: -1,
-        },
-      );
-    },
-    Error,
-    "Growth factor must be greater than 1",
-  );
+  for (const growthFactor of rejected) {
+    assertThrows(
+      () => autoGrowBuffer((_buffer) => "success", { growthFactor }),
+      Error,
+      "Growth factor must be greater than 1",
+    );
+  }
 });
 
 Deno.test("autoGrowBuffer - minimum growth guarantee", () => {
@@ -209,44 +152,38 @@ Deno.test("autoGrowBuffer - minimum growth guarantee", () => {
 Deno.test("autoGrowBuffer - small growth factor edge case", () => {
   // Test with growth factor that would result in same size due to truncation
   // This tests the Math.max fix that ensures at least 1 byte growth
-  let attemptCount = 0;
-  const result = autoGrowBuffer(
-    (buffer) => {
-      attemptCount++;
-      if (buffer.length < 5) {
-        throw new RangeError("Buffer too small");
-      }
-      return `success after ${attemptCount} attempts`;
-    },
-    {
-      initialSize: 1,
-      growthFactor: 1.01, // Very small growth factor
-    },
-  );
+  const fill = spy((buffer: Uint8Array) => {
+    if (buffer.length < 5) {
+      throw new RangeError("Buffer too small");
+    }
+    return "encoded";
+  });
 
-  assertEquals(result, "success after 5 attempts");
-  assertEquals(attemptCount, 5);
+  const result = autoGrowBuffer(fill, {
+    initialSize: 1,
+    growthFactor: 1.01, // Very small growth factor
+  });
+
+  assertEquals(result, "encoded");
+  assertSpyCalls(fill, 5);
 });
 
 Deno.test("autoGrowBuffer - integer truncation safety", () => {
   // Test that truncation doesn't cause infinite loops
-  let attemptCount = 0;
-  const result = autoGrowBuffer(
-    (buffer) => {
-      attemptCount++;
-      if (buffer.length < 3) {
-        throw new RangeError("Buffer too small");
-      }
-      return `success after ${attemptCount} attempts`;
-    },
-    {
-      initialSize: 1,
-      growthFactor: 1.5, // This will truncate to same size initially
-    },
-  );
+  const fill = spy((buffer: Uint8Array) => {
+    if (buffer.length < 3) {
+      throw new RangeError("Buffer too small");
+    }
+    return "encoded";
+  });
 
-  assertEquals(result, "success after 3 attempts");
-  assertEquals(attemptCount, 3);
+  const result = autoGrowBuffer(fill, {
+    initialSize: 1,
+    growthFactor: 1.5, // This will truncate to same size initially
+  });
+
+  assertEquals(result, "encoded");
+  assertSpyCalls(fill, 3);
 });
 
 Deno.test("autoGrowBuffer - robustness with edge case configurations", () => {
@@ -258,21 +195,16 @@ Deno.test("autoGrowBuffer - robustness with edge case configurations", () => {
   ];
 
   for (const config of testCases) {
-    let attemptCount = 0;
-    const result = autoGrowBuffer(
-      (buffer) => {
-        attemptCount++;
-        if (buffer.length < 10) {
-          throw new RangeError("Buffer too small");
-        }
-        return `success with ${config.growthFactor} growth factor`;
-      },
-      config,
-    );
+    const fill = spy((buffer: Uint8Array) => {
+      if (buffer.length < 10) {
+        throw new RangeError("Buffer too small");
+      }
+      return "encoded";
+    });
 
-    assertEquals(result, `success with ${config.growthFactor} growth factor`);
+    assertEquals(autoGrowBuffer(fill, config), "encoded");
     // Ensure it doesn't take too many attempts (indicating no infinite loop)
-    assertEquals(attemptCount <= 10, true);
+    assertLessOrEqual(fill.calls.length, 10);
   }
 });
 

--- a/packages/@hertzg/binstruct/lazy/lazy.test.ts
+++ b/packages/@hertzg/binstruct/lazy/lazy.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals } from "@std/assert";
+import { assertSpyCalls, spy } from "@std/testing/mock";
 import { lazy } from "./lazy.ts";
 import { type Coder, type Context, createContext } from "../core.ts";
 import { u8be } from "../numeric/numeric.ts";
@@ -24,26 +25,20 @@ Deno.test("lazy - round-trips like the coder it wraps", () => {
 });
 
 Deno.test("lazy - does not call the factory until first use", () => {
-  let builds = 0;
-  const coder = lazy(() => {
-    builds++;
-    return u8be();
-  });
+  const factory = spy(() => u8be());
+  const coder = lazy(factory);
 
-  assertEquals(builds, 0);
+  assertSpyCalls(factory, 0);
 
   const buffer = new Uint8Array(4);
   coder.encode(7, buffer);
 
-  assertEquals(builds, 1);
+  assertSpyCalls(factory, 1);
 });
 
 Deno.test("lazy - builds the inner coder at most once across many calls", () => {
-  let builds = 0;
-  const coder = lazy(() => {
-    builds++;
-    return u8be();
-  });
+  const factory = spy(() => u8be());
+  const coder = lazy(factory);
 
   const buffer = new Uint8Array(4);
   for (let i = 0; i < 5; i++) {
@@ -51,7 +46,7 @@ Deno.test("lazy - builds the inner coder at most once across many calls", () => 
     coder.decode(buffer);
   }
 
-  assertEquals(builds, 1);
+  assertSpyCalls(factory, 1);
 });
 
 Deno.test("lazy - shares a single context across nested encode/decode calls", () => {
@@ -81,41 +76,49 @@ interface FrameHost {
   rest: Uint8Array;
 }
 
-// `lazyFrame` closes the cycle: it's created before `frameCoder` exists, but
-// its factory (`() => frameCoder`) isn't invoked until the first
-// encode/decode, by which point `frameCoder`'s own initializer has finished.
-const lazyFrame: Coder<Frame> = lazy(() => frameCoder);
+// `lazy()` memoizes the coder its factory returns, so each test builds its own
+// pair rather than sharing one across the file — otherwise the second test to
+// run would only ever see an already-resolved cycle.
+function makeFrameCoder(): Coder<Frame> {
+  // `lazyFrame` closes the cycle: it's created before `frameCoder` exists, but
+  // its factory (`() => frameCoder`) isn't invoked until the first
+  // encode/decode, by which point `frameCoder`'s own initializer has finished.
+  const lazyFrame: Coder<Frame> = lazy(() => frameCoder);
 
-// `rest` is a greedy `bytes()` field, so it always consumes everything left
-// in the view it's handed. Encoding first (to learn the exact byte count)
-// and then decoding only that exact slice keeps every level self-delimiting
-// without needing an explicit length field.
-const frameCoder: Coder<Frame> = refine(
-  struct({ hasNext: u8be() as unknown as Coder<0 | 1>, rest: bytes() }),
-  {
-    refine: (host: FrameHost, ctx: Context): Frame => {
-      if (host.hasNext === 0) {
-        return { hasNext: 0, rest: host.rest };
-      }
-      const [rest] = lazyFrame.decode(host.rest, ctx);
-      return { hasNext: 1, rest };
+  // `rest` is a greedy `bytes()` field, so it always consumes everything left
+  // in the view it's handed. Encoding first (to learn the exact byte count)
+  // and then decoding only that exact slice keeps every level self-delimiting
+  // without needing an explicit length field.
+  const frameCoder: Coder<Frame> = refine(
+    struct({ hasNext: u8be() as unknown as Coder<0 | 1>, rest: bytes() }),
+    {
+      refine: (host: FrameHost, ctx: Context): Frame => {
+        if (host.hasNext === 0) {
+          return { hasNext: 0, rest: host.rest };
+        }
+        const [rest] = lazyFrame.decode(host.rest, ctx);
+        return { hasNext: 1, rest };
+      },
+      unrefine: (frame: Frame, ctx: Context): FrameHost => {
+        if (frame.hasNext === 0) {
+          return { hasNext: 0, rest: frame.rest as Uint8Array };
+        }
+        const scratch = new Uint8Array(1024);
+        const bytesWritten = lazyFrame.encode(
+          frame.rest as Frame,
+          scratch,
+          ctx,
+        );
+        return { hasNext: 1, rest: scratch.subarray(0, bytesWritten) };
+      },
     },
-    unrefine: (frame: Frame, ctx: Context): FrameHost => {
-      if (frame.hasNext === 0) {
-        return { hasNext: 0, rest: frame.rest as Uint8Array };
-      }
-      const scratch = new Uint8Array(1024);
-      const bytesWritten = lazyFrame.encode(
-        frame.rest as Frame,
-        scratch,
-        ctx,
-      );
-      return { hasNext: 1, rest: scratch.subarray(0, bytesWritten) };
-    },
-  },
-)();
+  )();
+
+  return frameCoder;
+}
 
 Deno.test("lazy - self-referential graph round-trips through multiple levels", () => {
+  const frameCoder = makeFrameCoder();
   const value: Frame = {
     hasNext: 1,
     rest: {
@@ -136,6 +139,7 @@ Deno.test("lazy - self-referential graph round-trips through multiple levels", (
 });
 
 Deno.test("lazy - self-referential graph round-trips a single leaf", () => {
+  const frameCoder = makeFrameCoder();
   const value: Frame = { hasNext: 0, rest: new Uint8Array(0) };
 
   const buffer = new Uint8Array(16);

--- a/packages/@hertzg/binstruct/refine/switch.test.ts
+++ b/packages/@hertzg/binstruct/refine/switch.test.ts
@@ -1,10 +1,11 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertStrictEquals, assertThrows } from "@std/assert";
+import { assertSpyCalls, spy } from "@std/testing/mock";
 import { struct } from "../struct/struct.ts";
 import { u8 } from "../numeric/numeric.ts";
 import { bytes } from "../bytes/bytes.ts";
 import { string } from "../string/string.ts";
 import { decode, encode } from "../helpers.ts";
-import { createContext } from "../core.ts";
+import { type Context, createContext } from "../core.ts";
 import { refineSwitch } from "./switch.ts";
 import type { Refiner } from "./refine.ts";
 
@@ -318,24 +319,19 @@ Deno.test("refineSwitch - encode error when selector returns invalid key", () =>
 });
 
 Deno.test("refineSwitch - context propagation", () => {
-  let refineContextDirection: string | undefined;
-  let unrefineContextDirection: string | undefined;
+  const refinePing = spy((packet: BasePacket, ctx: Context): PingPacket => ({
+    type: 1,
+    timestamp: decode(u8(), packet.data, ctx),
+  }));
+
+  const unrefinePing = spy((ping: PingPacket, ctx: Context): BasePacket => ({
+    type: ping.type,
+    data: encode(u8(), ping.timestamp, ctx, new Uint8Array(1)),
+  }));
 
   const pingRefiner: Refiner<BasePacket, PingPacket, []> = {
-    refine: (packet, ctx) => {
-      refineContextDirection = ctx.direction;
-      return {
-        type: 1,
-        timestamp: decode(u8(), packet.data, ctx),
-      };
-    },
-    unrefine: (ping, ctx) => {
-      unrefineContextDirection = ctx.direction;
-      return {
-        type: ping.type,
-        data: encode(u8(), ping.timestamp, ctx, new Uint8Array(1)),
-      };
-    },
+    refine: refinePing,
+    unrefine: unrefinePing,
   };
 
   const baseCoder = struct({
@@ -357,15 +353,17 @@ Deno.test("refineSwitch - context propagation", () => {
   const buffer = new Uint8Array(10);
   const ping: PingPacket = { type: 1, timestamp: 42 };
 
-  // Test encode context
+  // The caller's own context must reach the refiner — asserting on its
+  // `direction` alone would also accept a freshly created one.
   const encodeCtx = createContext("encode");
   packetCoder.encode(ping, buffer, encodeCtx);
-  assertEquals(unrefineContextDirection, "encode");
+  assertSpyCalls(unrefinePing, 1);
+  assertStrictEquals(unrefinePing.calls[0].args[1], encodeCtx);
 
-  // Test decode context
   const decodeCtx = createContext("decode");
   packetCoder.decode(buffer, decodeCtx);
-  assertEquals(refineContextDirection, "decode");
+  assertSpyCalls(refinePing, 1);
+  assertStrictEquals(refinePing.calls[0].args[1], decodeCtx);
 });
 
 Deno.test("refineSwitch - passthrough refiner for unknown values", () => {


### PR DESCRIPTION
Stacked on #232.

`lazy`, `buffer` and `refineSwitch` each recorded calls with a captured counter or a `let` assigned from inside the function under test. `@std/testing/mock` is already in the import map and used elsewhere in the monorepo; test-only imports do not enter `_deps.snap`.

- **buffer.test.ts** — the count was smuggled out through the return value (`"success after 4 attempts"`) and asserted as a string, so a call-count claim was disguised as a value claim and the two could not fail independently. Now `spy` + `assertSpyCalls`, callback returns a constant.
- **switch.test.ts** — the context test only recorded `ctx.direction`, which a freshly created context would also satisfy. Now asserts identity against the context the caller passed in.
- **lazy.test.ts** — the frame coders moved from module scope into a factory. `lazy()` memoizes, so sharing them meant the second test to run only ever saw an already-resolved cycle.

`deno task lint` and `deno task test` both exit 0.