### PR TITLE
chore(@hertzg/binstruct): make tests that could never fail assert something

### DIFF
--- a/packages/@hertzg/binstruct/bits/bit-struct.test.ts
+++ b/packages/@hertzg/binstruct/bits/bit-struct.test.ts
@@ -1,8 +1,13 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import {
+  assertEquals,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
 import { bitStruct } from "./bit-struct.ts";
 import { struct } from "../struct/struct.ts";
 import { u32le } from "../numeric/numeric.ts";
 import { createContext } from "../core.ts";
+import { ref } from "../ref/ref.ts";
 
 Deno.test("bitStruct: schema validation", async (t) => {
   await t.step("rejects bit count < 1", () => {
@@ -67,8 +72,8 @@ Deno.test("bitStruct: schema validation", async (t) => {
       () => bitStruct({ a: 5 }),
       Error,
     );
-    assertEquals(error.message.includes("Add 3 padding bit(s)"), true);
-    assertEquals(error.message.includes("{ _padding: 3 }"), true);
+    assertStringIncludes(error.message, "Add 3 padding bit(s)");
+    assertStringIncludes(error.message, "{ _padding: 3 }");
   });
 });
 
@@ -342,10 +347,7 @@ Deno.test("bitStruct: edge cases", async (t) => {
     const buffer = new Uint8Array(4);
 
     coder.encode(original, buffer);
-    assertEquals(buffer[0], 0);
-    assertEquals(buffer[1], 0);
-    assertEquals(buffer[2], 0);
-    assertEquals(buffer[3], 0);
+    assertEquals(buffer, new Uint8Array([0, 0, 0, 0]));
 
     const [decoded] = coder.decode(buffer);
     assertEquals(decoded, original);
@@ -358,10 +360,7 @@ Deno.test("bitStruct: edge cases", async (t) => {
     const buffer = new Uint8Array(4);
 
     coder.encode(original, buffer);
-    assertEquals(buffer[0], 0xFF);
-    assertEquals(buffer[1], 0xFF);
-    assertEquals(buffer[2], 0xFF);
-    assertEquals(buffer[3], 0xFF);
+    assertEquals(buffer, new Uint8Array([0xFF, 0xFF, 0xFF, 0xFF]));
 
     const [decoded] = coder.decode(buffer);
     assertEquals(decoded, original);
@@ -417,13 +416,12 @@ Deno.test("bitStruct: context integration", async (t) => {
   await t.step("stores value in context during encode", () => {
     const coder = bitStruct({ a: 4, b: 4 });
     const ctx = createContext("encode");
-    const value = { a: 15, b: 7 };
     const buffer = new Uint8Array(1);
 
-    coder.encode(value, buffer, ctx);
+    coder.encode({ a: 15, b: 7 }, buffer, ctx);
 
-    // Context should have the encoded value stored
-    // (verified by the fact that refs would be able to access it)
+    // `ref` throws unless the coder published itself to the context.
+    assertEquals(ref(coder)(ctx), { a: 15, b: 7 });
   });
 
   await t.step("stores value in context during decode", () => {
@@ -433,8 +431,7 @@ Deno.test("bitStruct: context integration", async (t) => {
 
     coder.decode(buffer, ctx);
 
-    // Context should have the decoded value stored
-    // (verified by the fact that refs would be able to access it)
+    assertEquals(ref(coder)(ctx), { a: 15, b: 15 });
   });
 });
 

--- a/packages/@hertzg/binstruct/bytes/bytes.test.ts
+++ b/packages/@hertzg/binstruct/bytes/bytes.test.ts
@@ -10,7 +10,7 @@ Deno.test("bytes - fixed length", () => {
   const [decoded, read] = coder.decode(buffer);
 
   // Should truncate to the specified length
-  assertEquals(Array.from(decoded), [1, 2, 3, 4]);
+  assertEquals(decoded, new Uint8Array([1, 2, 3, 4]));
   assertEquals(written, 4);
   assertEquals(read, 4);
 });
@@ -23,8 +23,9 @@ Deno.test("bytes - variable length", () => {
   const written = coder.encode(data, buffer);
   const [decoded, read] = coder.decode(buffer);
 
-  // For variable length, should read/write the entire buffer
-  assertEquals(decoded, buffer);
+  // For variable length, should read/write the entire buffer. `decoded` is the
+  // input view itself, so assert on the written bytes rather than on identity.
+  assertEquals(decoded.subarray(0, data.length), new Uint8Array([1, 2, 3, 4, 5]));
   assertEquals(written, data.length);
   assertEquals(read, buffer.length);
 });

--- a/packages/@hertzg/binstruct/refine/fields.test.ts
+++ b/packages/@hertzg/binstruct/refine/fields.test.ts
@@ -95,11 +95,12 @@ Deno.test("refineFields: composes as a refineSwitch arm", () => {
   const written = coder.encode(wordValue, buffer);
   const [decoded] = coder.decode(buffer.subarray(0, written));
 
+  // `payload` is a union across the switch arms; narrowing it in a guard would
+  // let a wrong-arm result skip the assertion entirely, so cast and assert.
+  const payload = decoded.payload as { value: number };
+
   assertEquals(decoded.tag, 1);
-  assertEquals("value" in decoded.payload, true);
-  if ("value" in decoded.payload && typeof decoded.payload.value === "number") {
-    assertEquals(decoded.payload.value, 0xabcd);
-  }
+  assertEquals(payload.value, 0xabcd);
 });
 
 Deno.test("refineFields: round-trips an empty coder map (identity)", () => {


### PR DESCRIPTION
Stacked on #234.

Three tests passed regardless of what the code under test did:

- **bits/bit-struct.test.ts** — the two "context integration" steps ended in a comment claiming refs would verify the value was published, and asserted nothing. They now read it back through `ref(coder)(ctx)`. This is the same invariant whose absence in `arrayFL` went uncaught until #228.
- **bytes/bytes.test.ts** — `assertEquals(decoded, buffer)` compared `buffer` to itself, since `bytes()` with no length returns the input view by identity. The test named "should read/write the entire buffer" never checked the bytes round-tripped.
- **refine/fields.test.ts** — the load-bearing assertion sat inside a `typeof value === "number"` guard, so a wrong switch arm skipped it and the test passed green.

Also swaps two `assertEquals(msg.includes(x), true)` for `assertStringIncludes` and two unrolled per-byte checks for a whole-buffer compare, so failures print the actual message and bytes instead of `false !== true`.

`deno task lint` and `deno task test` both exit 0.