### PR TITLE
chore(@hertzg/binstruct): use @std/assert helpers instead of re-deriving them

### DIFF
--- a/packages/@hertzg/binstruct/array/length-prefixed.test.ts
+++ b/packages/@hertzg/binstruct/array/length-prefixed.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertAlmostEquals, assertEquals, assertThrows } from "@std/assert";
 import { f32be, f64be, s16be, u16be, u32be, u8be } from "../numeric/numeric.ts";
 import { stringNT } from "../string/null-terminated.ts";
 import { stringLP } from "../string/length-prefixed.ts";
@@ -39,7 +39,7 @@ Deno.test("arrayLP: basic functionality", async (t) => {
 
     assertEquals(decoded.length, data.length);
     for (let i = 0; i < data.length; i++) {
-      assertEquals(Math.abs(decoded[i] - data[i]) < 0.001, true);
+      assertAlmostEquals(decoded[i], data[i], 0.001);
     }
     assertEquals(bytesWritten, bytesRead);
   });
@@ -171,26 +171,16 @@ Deno.test("arrayLP: edge cases", async (t) => {
 
 Deno.test("arrayLP: error handling", async (t) => {
   await t.step("throws on buffer too small for length", () => {
+    // The u16be prefix needs 2 bytes; only 1 is available.
     const coder = arrayLP(u8be(), u16be());
-    const data = [1, 2, 3, 4, 5];
-
-    const buffer = new Uint8Array(100);
-    coder.encode(data, buffer);
-
-    const smallBuffer = new Uint8Array(1);
-    assertThrows(() => coder.decode(smallBuffer), Error);
+    assertThrows(() => coder.decode(new Uint8Array(1)), Error);
   });
 
   await t.step("throws on buffer too small for elements", () => {
+    // The u8be prefix reads cleanly and announces 5 u32be elements, but none
+    // of the 20 bytes they need are present.
     const coder = arrayLP(u32be(), u8be());
-    const data = [1, 2, 3, 4, 5];
-
-    const buffer = new Uint8Array(100);
-    coder.encode(data, buffer);
-
-    // Buffer too small for length field (1 byte) - this should cause an error
-    const smallBuffer = new Uint8Array(0);
-    assertThrows(() => coder.decode(smallBuffer), Error);
+    assertThrows(() => coder.decode(new Uint8Array([5])), Error);
   });
 
   await t.step("throws on empty buffer", () => {
@@ -254,7 +244,7 @@ Deno.test("arrayLP: floating point precision", async (t) => {
 
     assertEquals(decoded.length, data.length);
     for (let i = 0; i < data.length; i++) {
-      assertEquals(Math.abs(decoded[i] - data[i]) < 0.0001, true);
+      assertAlmostEquals(decoded[i], data[i], 0.0001);
     }
     assertEquals(bytesWritten, bytesRead);
   });
@@ -269,7 +259,7 @@ Deno.test("arrayLP: floating point precision", async (t) => {
 
     assertEquals(decoded.length, data.length);
     for (let i = 0; i < data.length; i++) {
-      assertEquals(Math.abs(decoded[i] - data[i]) < 0.000000000000001, true);
+      assertAlmostEquals(decoded[i], data[i], 0.000000000000001);
     }
     assertEquals(bytesWritten, bytesRead);
   });

--- a/packages/@hertzg/binstruct/examples.test.ts
+++ b/packages/@hertzg/binstruct/examples.test.ts
@@ -185,15 +185,10 @@ Deno.test("Comprehensive examples showcasing all library functionality", async (
     bytesStructCoder.encode(testData, buffer);
     const [decoded] = bytesStructCoder.decode(buffer);
 
+    assertEquals(decoded.fixedBytes, testData.fixedBytes);
     assertEquals(
-      Array.from(decoded.fixedBytes),
-      Array.from(testData.fixedBytes),
-      "Fixed bytes should match",
-    );
-    assertEquals(
-      Array.from(decoded.variableBytes.slice(0, testData.variableBytes.length)),
-      Array.from(testData.variableBytes),
-      "Variable bytes should match",
+      decoded.variableBytes.slice(0, testData.variableBytes.length),
+      testData.variableBytes,
     );
     // bytes() without a length reads the entire remaining buffer on decode,
     // so bytesRead will be larger than bytesWritten
@@ -238,53 +233,7 @@ Deno.test("Comprehensive examples showcasing all library functionality", async (
     const bytesWritten = personCoder.encode(testData, buffer);
     const [decoded, bytesRead] = personCoder.decode(buffer);
 
-    assertEquals(decoded.id, testData.id, "ID should match");
-    assertEquals(decoded.name, testData.name, "Name should match");
-    assertEquals(decoded.age, testData.age, "Age should match");
-    assertEquals(
-      decoded.addresses.length,
-      testData.addresses.length,
-      "Addresses count should match",
-    );
-    assertEquals(
-      decoded.phones.length,
-      testData.phones.length,
-      "Phones count should match",
-    );
-
-    // Verify addresses
-    for (let i = 0; i < testData.addresses.length; i++) {
-      assertEquals(
-        decoded.addresses[i].street,
-        testData.addresses[i].street,
-        `Address ${i} street should match`,
-      );
-      assertEquals(
-        decoded.addresses[i].city,
-        testData.addresses[i].city,
-        `Address ${i} city should match`,
-      );
-      assertEquals(
-        decoded.addresses[i].zipCode,
-        testData.addresses[i].zipCode,
-        `Address ${i} zip code should match`,
-      );
-    }
-
-    // Verify phones
-    for (let i = 0; i < testData.phones.length; i++) {
-      assertEquals(
-        decoded.phones[i].countryCode,
-        testData.phones[i].countryCode,
-        `Phone ${i} country code should match`,
-      );
-      assertEquals(
-        decoded.phones[i].number,
-        testData.phones[i].number,
-        `Phone ${i} number should match`,
-      );
-    }
-
+    assertEquals(decoded, testData);
     assertEquals(
       bytesWritten,
       bytesRead,
@@ -330,16 +279,8 @@ Deno.test("Comprehensive examples showcasing all library functionality", async (
       testData.dataLength,
       "Data length should match",
     );
-    assertEquals(
-      Array.from(decoded.header),
-      Array.from(testData.header),
-      "Header data should match",
-    );
-    assertEquals(
-      Array.from(decoded.data),
-      Array.from(testData.data),
-      "Data should match",
-    );
+    assertEquals(decoded.header, testData.header, "Header data should match");
+    assertEquals(decoded.data, testData.data, "Data should match");
     assertEquals(decoded.checksum, testData.checksum, "Checksum should match");
     assertEquals(
       bytesWritten,
@@ -418,44 +359,6 @@ Deno.test("Comprehensive examples showcasing all library functionality", async (
     const buffer = new Uint8Array(1024);
     const bytesWritten = helloReplyCoder.encode(testData, buffer);
     const [decoded, bytesRead] = helloReplyCoder.decode(buffer);
-
-    // Verify basic fields
-    assertEquals(decoded.version, testData.version, "Version should match");
-    assertEquals(decoded.opcode, testData.opcode, "Opcode should match");
-    assertEquals(decoded.smac, testData.smac, "Source MAC should match");
-    assertEquals(decoded.dmac, testData.dmac, "Destination MAC should match");
-    assertEquals(decoded.sequence, testData.sequence, "Sequence should match");
-    assertEquals(decoded.errCode, testData.errCode, "Error code should match");
-    assertEquals(decoded.length, testData.length, "Length should match");
-    assertEquals(decoded.offset, testData.offset, "Offset should match");
-    assertEquals(decoded.flag, testData.flag, "Flag should match");
-    assertEquals(decoded.tokenId, testData.tokenId, "Token ID should match");
-    assertEquals(decoded.reserved, testData.reserved, "Reserved should match");
-
-    // Verify TLV data
-    assertEquals(
-      decoded.tlvs.length,
-      testData.tlvs.length,
-      "Number of TLVs should match",
-    );
-
-    for (let i = 0; i < testData.tlvs.length; i++) {
-      assertEquals(
-        decoded.tlvs[i].type,
-        testData.tlvs[i].type,
-        `TLV ${i} type should match`,
-      );
-      assertEquals(
-        decoded.tlvs[i].length,
-        testData.tlvs[i].length,
-        `TLV ${i} length should match`,
-      );
-      assertEquals(
-        decoded.tlvs[i].value,
-        testData.tlvs[i].value,
-        `TLV ${i} value should match`,
-      );
-    }
 
     // Verify encoding/decoding integrity
     assertEquals(

--- a/packages/@hertzg/binstruct/struct/struct.test.ts
+++ b/packages/@hertzg/binstruct/struct/struct.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertAlmostEquals, assertEquals, assertThrows } from "@std/assert";
 import { struct } from "./struct.ts";
 import {
   f32be,
@@ -64,8 +64,8 @@ Deno.test("struct: basic functionality", async (t) => {
     assertEquals(decoded.s8, data.s8);
     assertEquals(decoded.s16, data.s16);
     assertEquals(decoded.s32, data.s32);
-    assertEquals(Math.abs(decoded.f32 - data.f32) < 0.0001, true);
-    assertEquals(Math.abs(decoded.f64 - data.f64) < 0.000000000000001, true);
+    assertAlmostEquals(decoded.f32, data.f32, 0.0001);
+    assertAlmostEquals(decoded.f64, data.f64, 0.000000000000001);
     assertEquals(bytesWritten, bytesRead);
   });
 
@@ -102,10 +102,7 @@ Deno.test("struct: basic functionality", async (t) => {
     assertEquals(decoded.scores, gameState.scores);
     assertEquals(decoded.positions.length, gameState.positions.length);
     for (let i = 0; i < gameState.positions.length; i++) {
-      assertEquals(
-        Math.abs(decoded.positions[i] - gameState.positions[i]) < 0.001,
-        true,
-      );
+      assertAlmostEquals(decoded.positions[i], gameState.positions[i], 0.001);
     }
     assertEquals(bytesWritten, bytesRead);
   });
@@ -129,10 +126,7 @@ Deno.test("struct: basic functionality", async (t) => {
     const bytesWritten = userCoder.encode(user, buffer);
     const [decoded, bytesRead] = userCoder.decode(buffer);
 
-    assertEquals(decoded.id, user.id);
-    assertEquals(decoded.name, user.name);
-    assertEquals(decoded.email, user.email);
-    assertEquals(decoded.bio, user.bio);
+    assertEquals(decoded, user);
     assertEquals(bytesWritten, bytesRead);
   });
 });
@@ -261,11 +255,7 @@ Deno.test("struct: edge cases", async (t) => {
     const bytesWritten = zeroCoder.encode(data, buffer);
     const [decoded, bytesRead] = zeroCoder.decode(buffer);
 
-    assertEquals(decoded.u8, data.u8);
-    assertEquals(decoded.u16, data.u16);
-    assertEquals(decoded.u32, data.u32);
-    assertEquals(decoded.f32, data.f32);
-    assertEquals(decoded.f64, data.f64);
+    assertEquals(decoded, data);
     assertEquals(bytesWritten, bytesRead);
   });
 
@@ -315,10 +305,7 @@ Deno.test("struct: edge cases", async (t) => {
     const bytesWritten = configCoder.encode(config, buffer);
     const [decoded, bytesRead] = configCoder.decode(buffer);
 
-    assertEquals(decoded.version, config.version);
-    assertEquals(decoded.names, config.names);
-    assertEquals(decoded.tags, config.tags);
-    assertEquals(decoded.description, config.description);
+    assertEquals(decoded, config);
     assertEquals(bytesWritten, bytesRead);
   });
 });
@@ -330,11 +317,7 @@ Deno.test("struct: error handling", async (t) => {
       age: u8be(),
     });
 
-    const data = { id: 12345, age: 30 };
-    const buffer = new Uint8Array(100);
-    coder.encode(data, buffer);
-
-    // Try to decode with a buffer that's too small for the first property
+    // Too small for the leading u32be
     const smallBuffer = new Uint8Array(2);
     assertThrows(() => coder.decode(smallBuffer), Error);
   });
@@ -345,11 +328,7 @@ Deno.test("struct: error handling", async (t) => {
       age: u32be(),
     });
 
-    const data = { id: 123, age: 30 };
-    const buffer = new Uint8Array(100);
-    coder.encode(data, buffer);
-
-    // Create a buffer that's big enough for first property but not for second
+    // Big enough for the leading u8be but not for the u32be after it
     const partialBuffer = new Uint8Array(2);
     assertThrows(() => coder.decode(partialBuffer), Error);
   });
@@ -429,9 +408,9 @@ Deno.test("struct: floating point precision", async (t) => {
     const bytesWritten = coder.encode(data, buffer);
     const [decoded, bytesRead] = coder.decode(buffer);
 
-    assertEquals(Math.abs(decoded.x - data.x) < 0.0001, true);
-    assertEquals(Math.abs(decoded.y - data.y) < 0.0001, true);
-    assertEquals(Math.abs(decoded.z - data.z) < 0.0001, true);
+    assertAlmostEquals(decoded.x, data.x, 0.0001);
+    assertAlmostEquals(decoded.y, data.y, 0.0001);
+    assertAlmostEquals(decoded.z, data.z, 0.0001);
     assertEquals(bytesWritten, bytesRead);
   });
 
@@ -447,9 +426,9 @@ Deno.test("struct: floating point precision", async (t) => {
     const bytesWritten = coder.encode(data, buffer);
     const [decoded, bytesRead] = coder.decode(buffer);
 
-    assertEquals(Math.abs(decoded.pi - data.pi) < 0.000000000000001, true);
-    assertEquals(Math.abs(decoded.e - data.e) < 0.000000000000001, true);
-    assertEquals(Math.abs(decoded.phi - data.phi) < 0.000000000000001, true);
+    assertAlmostEquals(decoded.pi, data.pi, 0.000000000000001);
+    assertAlmostEquals(decoded.e, data.e, 0.000000000000001);
+    assertAlmostEquals(decoded.phi, data.phi, 0.000000000000001);
     assertEquals(bytesWritten, bytesRead);
   });
 });
@@ -480,11 +459,7 @@ Deno.test("struct: complex nested structures", async (t) => {
     const bytesWritten = nestedCoder.encode(data, buffer);
     const [decoded, bytesRead] = nestedCoder.decode(buffer);
 
-    assertEquals(decoded.id, data.id);
-    assertEquals(decoded.tags, data.tags);
-    assertEquals(decoded.scores, data.scores);
-    assertEquals(decoded.metadata.created, data.metadata.created);
-    assertEquals(decoded.metadata.updated, data.metadata.updated);
+    assertEquals(decoded, data);
     assertEquals(bytesWritten, bytesRead);
   });
 
@@ -512,14 +487,7 @@ Deno.test("struct: complex nested structures", async (t) => {
     const bytesWritten = gameCoder.encode(data, buffer);
     const [decoded, bytesRead] = gameCoder.decode(buffer);
 
-    assertEquals(decoded.gameId, data.gameId);
-    assertEquals(decoded.players.length, data.players.length);
-    assertEquals(decoded.players[0].id, data.players[0].id);
-    assertEquals(decoded.players[0].name, data.players[0].name);
-    assertEquals(decoded.players[0].score, data.players[0].score);
-    assertEquals(decoded.players[1].id, data.players[1].id);
-    assertEquals(decoded.players[1].name, data.players[1].name);
-    assertEquals(decoded.players[1].score, data.players[1].score);
+    assertEquals(decoded, data);
     assertEquals(bytesWritten, bytesRead);
   });
 });


### PR DESCRIPTION
Stacked on #235.

- **14 × `assertEquals(Math.abs(a - b) < eps, true)` → `assertAlmostEquals`.** Every float comparison in the package hand-derived the tolerance check and then asserted the boolean, so a regression in `f32be`/`f64be` reported as `false !== true` with neither number nor tolerance in the message.
- **Dropped `Array.from()` around typed-array compares.** `assertEquals` handles `Uint8Array` directly, and converting first *weakened* the assertion — a coder returning `number[]` would still have passed, and the buffer type is part of the contract here.
- **Hand-written deep-equal loops → `assertEquals` on the value**, and removed assertions already subsumed by a whole-object compare in the same step. In the TLV example that is 35 lines that could not fail unless the line below them also failed.
- **Dropped dead setup** from four error tests that encoded into a 100-byte buffer and then decoded a different, never-written one, plus a step whose comment contradicted its own name.

`deno task lint` and `deno task test` both exit 0.