### PR TITLE
chore(@hertzg/binstruct): cut wasted work from the numeric and helper tests

### DIFF
--- a/packages/@hertzg/binstruct/helpers.test.ts
+++ b/packages/@hertzg/binstruct/helpers.test.ts
@@ -29,27 +29,50 @@ Deno.test("encode - provided target buffer", () => {
   assertEquals(encoded.buffer, buffer.buffer);
 });
 
-Deno.test("encode - large data requiring growth", async (t) => {
-  await t.step("array with 10000 elements", () => {
-    const coder = struct({
-      data: array(u8le(), u16le()),
-    });
-    const largeArray = new Array(10000).fill(42);
-    const data = { data: largeArray };
+Deno.test("encode - grows the target buffer to fit the payload", async (t) => {
+  // How many times the grow-and-retry loop runs is driven by `initialSize`,
+  // not by payload size — a one-byte initial buffer walks more of the loop
+  // than a huge payload does against the 4KB default, at a fraction of the
+  // cost. The large-payload step below is here to prove real-scale encoding,
+  // not to reach the growth path.
+  await t.step("fits within the initial buffer without growing", () => {
+    const coder = struct({ data: array(u8le(), u16le()) });
 
-    const encoded = encode(coder, data);
-    assertEquals(encoded.length, 10002); // 2 bytes length + 10000 bytes data
+    const encoded = encode(coder, { data: new Array(100).fill(42) });
+    assertEquals(encoded.length, 102); // 2 bytes length + 100 bytes data
   });
 
-  await t.step("very large array requiring multiple growth cycles", () => {
-    const coder = struct({
-      data: array(u8le(), u32le()),
-    });
-    const largeArray = new Array(50000).fill(42);
-    const data = { data: largeArray };
+  await t.step("grows repeatedly from a one-byte initial buffer", () => {
+    const coder = struct({ data: array(u8le(), u16le()) });
 
-    const encoded = encode(coder, data);
-    assertEquals(encoded.length, 50004); // 4 bytes length + 50000 bytes data
+    const encoded = encode(
+      coder,
+      { data: new Array(100).fill(42) },
+      undefined,
+      undefined,
+      { initialSize: 1 },
+    );
+    assertEquals(encoded.length, 102); // 2 bytes length + 100 bytes data
+  });
+
+  await t.step("grows past a 4-byte length prefix", () => {
+    const coder = struct({ data: array(u8le(), u32le()) });
+
+    const encoded = encode(
+      coder,
+      { data: new Array(100).fill(42) },
+      undefined,
+      undefined,
+      { initialSize: 1 },
+    );
+    assertEquals(encoded.length, 104); // 4 bytes length + 100 bytes data
+  });
+
+  await t.step("encodes a payload larger than the default initial size", () => {
+    const coder = struct({ data: array(u8le(), u16le()) });
+
+    const encoded = encode(coder, { data: new Array(10000).fill(42) });
+    assertEquals(encoded.length, 10002); // 2 bytes length + 10000 bytes data
   });
 });
 
@@ -153,9 +176,7 @@ Deno.test("round-trip integrity", async (t) => {
     // Decode
     const decodedData = decode(coder, encoded);
 
-    assertEquals(decodedData.id, originalData.id);
-    assertEquals(decodedData.name, originalData.name);
-    assertEquals(decodedData.active, originalData.active);
+    assertEquals(decodedData, originalData);
   });
 
   await t.step("complex nested structure", () => {
@@ -186,15 +207,7 @@ Deno.test("round-trip integrity", async (t) => {
     // Decode
     const decodedData = decode(outerCoder, encoded);
 
-    assertEquals(decodedData.id, originalData.id);
-    assertEquals(decodedData.points.length, originalData.points.length);
-    assertEquals(decodedData.points[0].x, originalData.points[0].x);
-    assertEquals(decodedData.points[0].y, originalData.points[0].y);
-    assertEquals(decodedData.points[1].x, originalData.points[1].x);
-    assertEquals(decodedData.points[1].y, originalData.points[1].y);
-    assertEquals(decodedData.points[2].x, originalData.points[2].x);
-    assertEquals(decodedData.points[2].y, originalData.points[2].y);
-    assertEquals(decodedData.metadata, originalData.metadata);
+    assertEquals(decodedData, originalData);
   });
 });
 
@@ -234,40 +247,7 @@ Deno.test("edge cases", async (t) => {
     assertEquals(encoded.length, 7);
 
     const decoded = decode(coder, encoded);
-    assertEquals(decoded.a, 0);
-    assertEquals(decoded.b, 0);
-    assertEquals(decoded.c, 0);
+    assertEquals(decoded, data);
   });
 });
 
-Deno.test("buffer growth strategy", async (t) => {
-  await t.step("small data uses initial buffer", () => {
-    const coder = struct({ value: u8le() });
-    const data = { value: 42 };
-
-    const encoded = encode(coder, data);
-    assertEquals(encoded.length, 1);
-  });
-
-  await t.step("medium data triggers growth", () => {
-    const coder = struct({
-      data: array(u8le(), u16le()),
-    });
-    const mediumArray = new Array(2000).fill(42);
-    const data = { data: mediumArray };
-
-    const encoded = encode(coder, data);
-    assertEquals(encoded.length, 2002); // 2 bytes length + 2000 bytes data
-  });
-
-  await t.step("large data uses chunked growth", () => {
-    const coder = struct({
-      data: array(u8le(), u32le()),
-    });
-    const largeArray = new Array(100000).fill(42);
-    const data = { data: largeArray };
-
-    const encoded = encode(coder, data);
-    assertEquals(encoded.length, 100004); // 4 bytes length + 100000 bytes data
-  });
-});

--- a/packages/@hertzg/binstruct/numeric/numeric.test.ts
+++ b/packages/@hertzg/binstruct/numeric/numeric.test.ts
@@ -1,13 +1,12 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertAlmostEquals, assertEquals, assertThrows } from "@std/assert";
 import type { Coder } from "../core.ts";
 // deno-fmt-ignore
 import {
-  type Endianness,
-  f16, f16be, f16le, f32, f32be, f32le, f64, f64be, f64le,
-  u8, u8be, u8le, s8, s8be, s8le,
-  u16, u16be, u16le, s16, s16be, s16le,
-  u32, u32be, u32le, s32, s32be, s32le,
-  s64, s64be, s64le, u64, u64be, u64le,
+  f16be, f16le, f32be, f32le, f64be, f64le,
+  u8, u8be, u8le, s8be, s8le,
+  u16be, u16le, s16be, s16le,
+  u32be, u32le, s32be, s32le,
+  s64be, s64le, u64be, u64le,
 } from "./numeric.ts";
 
 // Truth table for testing numeric types
@@ -77,40 +76,34 @@ const TRUTH_TABLE = [
 ] as const;
 
 // Test each type
-testNumericType("u8", u8, u8le, u8be, 1);
+testNumericType("u8", u8le, u8be, 1);
 
-testNumericType("s8", s8, s8le, s8be, 1);
+testNumericType("s8", s8le, s8be, 1);
 
-testNumericType("u16", u16, u16le, u16be, 2);
+testNumericType("u16", u16le, u16be, 2);
 
-testNumericType("s16", s16, s16le, s16be, 2);
+testNumericType("s16", s16le, s16be, 2);
 
-testNumericType("f16", f16, f16le, f16be, 2);
+testNumericType("f16", f16le, f16be, 2);
 
-testNumericType("u32", u32, u32le, u32be, 4);
+testNumericType("u32", u32le, u32be, 4);
 
-testNumericType("s32", s32, s32le, s32be, 4);
+testNumericType("s32", s32le, s32be, 4);
 
-testNumericType("f32", f32, f32le, f32be, 4);
+testNumericType("f32", f32le, f32be, 4);
 
-testNumericType("u64", u64, u64le, u64be, 8);
-testNumericType("s64", s64, s64le, s64be, 8);
-testNumericType("f64", f64, f64le, f64be, 8);
+testNumericType("u64", u64le, u64be, 8);
+testNumericType("s64", s64le, s64be, 8);
+testNumericType("f64", f64le, f64be, 8);
 
 // Helper function to convert big-endian bytes to little-endian
 function toLittleEndian(bytes: readonly number[]): number[] {
-  // For single-byte values, BE and LE are the same
-  if (bytes.length === 1) {
-    return [...bytes];
-  }
-  // For multi-byte values, reverse the byte order
   return [...bytes].reverse();
 }
 
 // Generic test function for each type
 function testNumericType<T extends number | bigint>(
   name: string,
-  _defaultType: (endianness: Endianness) => Coder<T>,
   littleEndianType: () => Coder<T>,
   bigEndianType: () => Coder<T>,
   expectedSize: number,
@@ -118,114 +111,100 @@ function testNumericType<T extends number | bigint>(
   const typeTests = TRUTH_TABLE.filter(([type]) => type === name);
 
   Deno.test(`${name}:`, async (t) => {
-    for (const [, value, bytesBe, description] of typeTests) {
-      await t.step("reads", async (t) => {
-        await t.step(`big-endian: ${description}`, async (t) => {
-          // Test reading from buffer with expected bytes
-          const buffer = new Uint8Array(bytesBe);
-          const [result] = bigEndianType().decode(buffer);
-          assertEquals(result, value as T);
+    // Each leaf step covers the aligned and the offset case for one truth-table
+    // row: they are the same claim about the same bytes, and folding them into
+    // one body keeps the offset case from depending on a parent step's locals.
+    await t.step("reads", async (t) => {
+      for (const [, value, bytesBe, description] of typeTests) {
+        await t.step(`big-endian: ${description}`, () => {
+          const coder = bigEndianType();
 
-          await t.step(`with offset`, () => {
-            const bufferWithOffset = new Uint8Array([0, 0, 0, 0, ...bytesBe]);
-            const view = bufferWithOffset.subarray(4, 4 + bytesBe.length);
-            const [result] = bigEndianType().decode(view);
-            assertEquals(result, value as T);
-          });
+          const [aligned] = coder.decode(new Uint8Array(bytesBe));
+          assertEquals(aligned, value as T);
+
+          const withOffset = new Uint8Array([0, 0, 0, 0, ...bytesBe]);
+          const [offset] = coder.decode(
+            withOffset.subarray(4, 4 + bytesBe.length),
+          );
+          assertEquals(offset, value as T);
         });
 
-        await t.step(`little-endian: ${description}`, async (t) => {
+        await t.step(`little-endian: ${description}`, () => {
+          const coder = littleEndianType();
           const bytesLe = toLittleEndian(bytesBe);
-          const buffer = new Uint8Array(bytesLe);
 
-          const [result] = littleEndianType().decode(buffer);
-          assertEquals(result, value as T);
+          const [aligned] = coder.decode(new Uint8Array(bytesLe));
+          assertEquals(aligned, value as T);
 
-          await t.step(`with offset`, () => {
-            const bufferWithOffset = new Uint8Array([0, 0, 0, 0, ...bytesLe]);
-            const view = bufferWithOffset.subarray(4, 4 + bytesLe.length);
-            const [result] = littleEndianType().decode(view);
-            assertEquals(result, value as T);
-          });
+          const withOffset = new Uint8Array([0, 0, 0, 0, ...bytesLe]);
+          const [offset] = coder.decode(
+            withOffset.subarray(4, 4 + bytesLe.length),
+          );
+          assertEquals(offset, value as T);
         });
-      });
+      }
+    });
 
-      await t.step("writes", async (t) => {
-        await t.step(`big-endian: ${description}`, async (t) => {
+    await t.step("writes", async (t) => {
+      for (const [, value, bytesBe, description] of typeTests) {
+        await t.step(`big-endian: ${description}`, () => {
+          const coder = bigEndianType();
+
           const buffer = new Uint8Array(bytesBe.length);
-          const bytesWritten = bigEndianType().encode(value as T, buffer);
-          assertEquals(bytesWritten, bytesBe.length);
+          assertEquals(coder.encode(value as T, buffer), bytesBe.length);
           assertEquals(buffer, new Uint8Array(bytesBe));
 
-          await t.step(`with offset`, () => {
-            const bufferWithOffset = new Uint8Array(bytesBe.length + 4);
-            const view = bufferWithOffset.subarray(4, 4 + bytesBe.length);
-            const bytesWritten = bigEndianType().encode(value as T, view);
-            assertEquals(bytesWritten, bytesBe.length);
-            assertEquals(
-              bufferWithOffset,
-              new Uint8Array([0, 0, 0, 0, ...bytesBe]),
-            );
-          });
+          const withOffset = new Uint8Array(bytesBe.length + 4);
+          const view = withOffset.subarray(4, 4 + bytesBe.length);
+          assertEquals(coder.encode(value as T, view), bytesBe.length);
+          assertEquals(withOffset, new Uint8Array([0, 0, 0, 0, ...bytesBe]));
         });
 
-        await t.step(`little-endian: ${description}`, async (t) => {
+        await t.step(`little-endian: ${description}`, () => {
+          const coder = littleEndianType();
           const bytesLe = toLittleEndian(bytesBe);
+
           const buffer = new Uint8Array(bytesLe.length);
-          const bytesWritten = littleEndianType().encode(value as T, buffer);
-          assertEquals(bytesWritten, bytesLe.length);
+          assertEquals(coder.encode(value as T, buffer), bytesLe.length);
           assertEquals(buffer, new Uint8Array(bytesLe));
 
-          await t.step(`with offset`, () => {
-            const bufferWithOffset = new Uint8Array(bytesLe.length + 4);
-            const view = bufferWithOffset.subarray(4, 4 + bytesLe.length);
-            const bytesWritten = littleEndianType().encode(value as T, view);
-            assertEquals(bytesWritten, bytesLe.length);
-            assertEquals(
-              bufferWithOffset,
-              new Uint8Array([0, 0, 0, 0, ...bytesLe]),
-            );
-          });
+          const withOffset = new Uint8Array(bytesLe.length + 4);
+          const view = withOffset.subarray(4, 4 + bytesLe.length);
+          assertEquals(coder.encode(value as T, view), bytesLe.length);
+          assertEquals(withOffset, new Uint8Array([0, 0, 0, 0, ...bytesLe]));
         });
-      });
+      }
+    });
 
-      await t.step("roundtrip", async (t) => {
-        await t.step(`big-endian: ${description}`, async (t) => {
-          // Write value to buffer, then read it back
+    await t.step("roundtrip", async (t) => {
+      for (const [, value, , description] of typeTests) {
+        await t.step(`big-endian: ${description}`, () => {
+          const coder = bigEndianType();
+
           const buffer = new Uint8Array(expectedSize);
-          const bytesWritten = bigEndianType().encode(value as T, buffer);
-          assertEquals(bytesWritten, expectedSize);
-          const [result] = bigEndianType().decode(buffer);
-          assertEquals(result, value as T);
+          assertEquals(coder.encode(value as T, buffer), expectedSize);
+          assertEquals(coder.decode(buffer)[0], value as T);
 
-          await t.step(`with offset`, () => {
-            const bufferWithOffset = new Uint8Array(expectedSize + 4);
-            const view = bufferWithOffset.subarray(4, 4 + expectedSize);
-            const bytesWritten = bigEndianType().encode(value as T, view);
-            assertEquals(bytesWritten, expectedSize);
-            const [result] = bigEndianType().decode(view);
-            assertEquals(result, value as T);
-          });
+          const withOffset = new Uint8Array(expectedSize + 4);
+          const view = withOffset.subarray(4, 4 + expectedSize);
+          assertEquals(coder.encode(value as T, view), expectedSize);
+          assertEquals(coder.decode(view)[0], value as T);
         });
 
-        await t.step(`little-endian: ${description}`, async (t) => {
+        await t.step(`little-endian: ${description}`, () => {
+          const coder = littleEndianType();
+
           const buffer = new Uint8Array(expectedSize);
-          const bytesWritten = littleEndianType().encode(value as T, buffer);
-          assertEquals(bytesWritten, expectedSize);
-          const [result] = littleEndianType().decode(buffer);
-          assertEquals(result, value as T);
+          assertEquals(coder.encode(value as T, buffer), expectedSize);
+          assertEquals(coder.decode(buffer)[0], value as T);
 
-          await t.step(`with offset`, () => {
-            const bufferWithOffset = new Uint8Array(expectedSize + 4);
-            const view = bufferWithOffset.subarray(4, 4 + expectedSize);
-            const bytesWritten = littleEndianType().encode(value as T, view);
-            assertEquals(bytesWritten, expectedSize);
-            const [result] = littleEndianType().decode(view);
-            assertEquals(result, value as T);
-          });
+          const withOffset = new Uint8Array(expectedSize + 4);
+          const view = withOffset.subarray(4, 4 + expectedSize);
+          assertEquals(coder.encode(value as T, view), expectedSize);
+          assertEquals(coder.decode(view)[0], value as T);
         });
-      });
-    }
+      }
+    });
 
     await t.step("size", async (t) => {
       await t.step("buffer too small for read", () => {
@@ -237,7 +216,18 @@ function testNumericType<T extends number | bigint>(
       });
 
       await t.step("buffer too small for write", () => {
-        // This test doesn't apply to the new API since encode takes a target buffer
+        // A short encode target must raise RangeError — that is the signal
+        // `autoGrowBuffer` catches to resize and retry (ADR 0009).
+        const [, value] = typeTests[0];
+        const buffer = new Uint8Array(Math.max(expectedSize - 1, 0));
+        assertThrows(
+          () => bigEndianType().encode(value as T, buffer),
+          RangeError,
+        );
+        assertThrows(
+          () => littleEndianType().encode(value as T, buffer),
+          RangeError,
+        );
       });
 
       await t.step("empty buffer", () => {
@@ -258,7 +248,7 @@ Deno.test("floating point precision", async (t) => {
     assertEquals(bytesWritten, 4);
     const [result] = f32be().decode(buffer);
     // Should be close but not necessarily exact due to floating point precision
-    assertEquals(Math.abs(result - value) < 0.0001, true);
+    assertAlmostEquals(result, value, 0.0001);
   });
 
   await t.step("f64 precision", () => {
@@ -268,7 +258,7 @@ Deno.test("floating point precision", async (t) => {
     assertEquals(bytesWritten, 8);
     const [result] = f64be().decode(buffer);
     // Should be very close due to double precision
-    assertEquals(Math.abs(result - value) < 0.000000000000001, true);
+    assertAlmostEquals(result, value, 0.000000000000001);
   });
 });
 


### PR DESCRIPTION
Stacked on #236. These two files were ~110ms of the suite's ~147ms of real test compute.

**numeric.test.ts — 694 steps → 340, 86ms → 45ms.** The `reads`/`writes`/`roundtrip` steps were opened *inside* the truth-table loop, so all three were recreated once per row, and each leaf nested a `with offset` child that existed only to reuse its parent's locals. Hoisting the groups above the loop and folding the offset case into the step body keeps every original assertion.

Its `buffer too small for write` step was an empty body with a comment saying the case no longer applied. It applies: a short encode target must raise `RangeError`, which is the signal `autoGrowBuffer` catches to resize and retry (ADR 0009). Restored, and it holds for all 11 numeric types. Also drops the dead `_defaultType` parameter, passed from 11 call sites and never read.

**helpers.test.ts.** Five near-identical steps reached the auto-grow path with 100k/50k/10k-element fixtures (48ms). Growth cycles are driven by `initialSize`, not payload size — `{ initialSize: 1 }` over 100 elements walks *more* of the loop for a fraction of the cost. One 10k case stays to prove real-scale encoding. One of the removed steps ("medium data triggers growth", 2000 elements → 2002 bytes) never grew at all, since that is under the 4096 default.

`deno task lint` and `deno task test` both exit 0.