### PR TITLE
chore(@hertzg/binstruct): drop duplicated tests and derived expectations

### DIFF
--- a/packages/@hertzg/binstruct/length.test.ts
+++ b/packages/@hertzg/binstruct/length.test.ts
@@ -23,29 +23,30 @@ Deno.test("isValidLength", () => {
 
 Deno.test("lengthRefGetSet", async (t) => {
   await t.step("without context", () => {
-    const mockCoder = u8be();
-    const mockCoderRef = ref(mockCoder);
+    const lengthCoder = u8be();
+    const lengthRef = ref(lengthCoder);
     assertEquals(lengthRefGet(null, 5), 5);
     assertEquals(lengthRefGet(undefined, 10), 10);
-    assertEquals(lengthRefGet(null, mockCoderRef), undefined);
-    assertEquals(lengthRefGet(undefined, mockCoderRef), undefined);
+    assertEquals(lengthRefGet(null, lengthRef), undefined);
+    assertEquals(lengthRefGet(undefined, lengthRef), undefined);
   });
 
   await t.step("with context", () => {
     const context = createContext("encode");
-    const mockCoder = u8be();
-    const mockCoderRef = ref(mockCoder);
+    const lengthCoder = u8be();
+    const lengthRef = ref(lengthCoder);
     assertEquals(lengthRefGet(context, 42), 42);
     assertEquals(lengthRefGet(context, 1000), 1000);
 
-    assertEquals(lengthRefGet({} as Context, mockCoderRef), undefined);
+    // A bare object stands in for a context built without ref storage.
+    assertEquals(lengthRefGet({} as Context, lengthRef), undefined);
     assertThrows(
-      () => lengthRefGet(context, mockCoderRef),
+      () => lengthRefGet(context, lengthRef),
       Error,
       "Ref not found",
     );
 
-    refSetValue(context, mockCoder, 123);
-    assertEquals(lengthRefGet(context, mockCoderRef), 123);
+    refSetValue(context, lengthCoder, 123);
+    assertEquals(lengthRefGet(context, lengthRef), 123);
   });
 });

--- a/packages/@hertzg/binstruct/ref/ref.test.ts
+++ b/packages/@hertzg/binstruct/ref/ref.test.ts
@@ -95,48 +95,7 @@ Deno.test("computedRef: basic functionality", async (t) => {
     // Verify the data matches
     assertEquals(decoded.width, data.width);
     assertEquals(decoded.height, data.height);
-    assertEquals(decoded.pixels.length, data.pixels.length);
-    for (let i = 0; i < data.pixels.length; i++) {
-      assertEquals(decoded.pixels[i].r, data.pixels[i].r);
-      assertEquals(decoded.pixels[i].g, data.pixels[i].g);
-      assertEquals(decoded.pixels[i].b, data.pixels[i].b);
-      assertEquals(decoded.pixels[i].a, data.pixels[i].a);
-    }
-    assertEquals(bytesWritten, bytesRead);
-  });
-
-  await t.step("works with different computation functions", () => {
-    const count = u16be();
-    const multiplier = u8be();
-
-    const coder = struct({
-      count: count,
-      multiplier: multiplier,
-      items: arrayFL(
-        u8be(),
-        computedRef(
-          [
-            ref(count),
-            ref(multiplier),
-          ],
-          (c, m) => c * m,
-        ),
-      ),
-    });
-
-    const data = {
-      count: 3,
-      multiplier: 2,
-      items: [1, 2, 3, 4, 5, 6],
-    };
-
-    const buffer = new Uint8Array(1000);
-    const bytesWritten = coder.encode(data, buffer);
-    const [decoded, bytesRead] = coder.decode(buffer);
-
-    assertEquals(decoded.count, data.count);
-    assertEquals(decoded.multiplier, data.multiplier);
-    assertEquals(decoded.items, data.items);
+    assertEquals(decoded.pixels, data.pixels);
     assertEquals(bytesWritten, bytesRead);
   });
 });

--- a/packages/@hertzg/binstruct/string/fixed-length.test.ts
+++ b/packages/@hertzg/binstruct/string/fixed-length.test.ts
@@ -31,7 +31,7 @@ Deno.test("string - fixed length - does not fit in byteLength", () => {
   const bytesWritten = coder.encode(testString, buffer);
   const [decoded, bytesRead] = coder.decode(buffer);
 
-  assertEquals(decoded, testString.slice(0, length));
+  assertEquals(decoded, "Hello");
   assertEquals(bytesWritten, bytesRead);
   assertEquals(bytesWritten, length);
 });
@@ -45,7 +45,7 @@ Deno.test("string - fixed length - empty string", () => {
   const bytesWritten = coder.encode(testString, buffer);
   const [decoded, bytesRead] = coder.decode(buffer);
 
-  assertEquals(decoded, `${"\0".repeat(length)}`);
+  assertEquals(decoded, "\0\0\0\0\0");
   assertNotEquals(bytesWritten, bytesRead);
   assertEquals(bytesWritten, testString.length);
   assertEquals(bytesRead, length);

--- a/packages/@hertzg/binstruct/string/string.test.ts
+++ b/packages/@hertzg/binstruct/string/string.test.ts
@@ -22,11 +22,6 @@ Deno.test("string(number) creates fixed-length coder", () => {
   assertEquals(coder[kCoderKind], kKindStringFL);
 });
 
-Deno.test("string(coder) creates length-prefixed coder", () => {
-  const coder = string(u16());
-  assertEquals(coder[kCoderKind], kKindStringLP);
-});
-
 Deno.test("string(ref) creates fixed-length coder with reference", () => {
   const coder = string(ref(u16()));
   assertEquals(coder[kCoderKind], kKindStringFL);


### PR DESCRIPTION
Stacked on #237.

- **string/string.test.ts** declared `"string(coder) creates length-prefixed coder"` twice, character for character. Deno permits the duplicate name, so it ran and reported twice.
- **ref/ref.test.ts** — `"works with different computation functions"` used the same `(a, b) => a * b` as the test above it, differing only in field names.
- **string/fixed-length.test.ts** — the truncation test expected `testString.slice(0, length)`. Truncation is the behaviour under test, so deriving the expectation from the input made it untestable. Written as a literal.
- **length.test.ts** — renames `mockCoder`, which is a real `u8be` coder used as a ref key rather than a stub, and says why a bare object stands in for a refs-less context.

`deno task lint` and `deno task test` both exit 0.